### PR TITLE
Release prep for v1.0.0

### DIFF
--- a/.github/workflows/auto-milestone.yml
+++ b/.github/workflows/auto-milestone.yml
@@ -1,0 +1,9 @@
+name: Auto-assign milestone
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  auto-milestone:
+    uses: ArtisanPack-UI/.github/.github/workflows/auto-milestone.yml@main

--- a/.github/workflows/auto-milestone.yml
+++ b/.github/workflows/auto-milestone.yml
@@ -6,4 +6,4 @@ on:
 
 jobs:
   auto-milestone:
-    uses: ArtisanPack-UI/.github/.github/workflows/auto-milestone.yml@main
+    uses: ArtisanPack-UI/.github/.github/workflows/auto-milestone.yml@7329ccfac5f658e9528413eb8a8e3cc5b5a95512 # main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,10 @@ jobs:
     name: Lint
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@8358ee0e2e8afe63c2fb8253d1d52085811ab1e5 # v2
         with:
           php-version: '8.4'
           extensions: dom, curl, libxml, mbstring, zip, pdo, sqlite, pdo_sqlite
@@ -27,7 +27,7 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache Composer dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
@@ -53,10 +53,10 @@ jobs:
         livewire: ['3.6', '4.0']
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@8358ee0e2e8afe63c2fb8253d1d52085811ab1e5 # v2
         with:
           php-version: '8.4'
           extensions: dom, curl, libxml, mbstring, zip, pdo, sqlite, pdo_sqlite
@@ -67,7 +67,7 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache Composer dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-lw${{ matrix.livewire }}-${{ hashFiles('**/composer.json') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,6 @@ jobs:
         run: ./vendor/bin/php-cs-fixer fix --dry-run --diff
 
       - name: Run PHPCS
-        continue-on-error: true
         run: ./vendor/bin/phpcs src/ database/ tests/ config/
 
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,15 +3,14 @@ name: CI
 on:
   push:
     branches: [main]
-    tags:
-      - 'v*'
   pull_request:
     branches: [main]
 
 jobs:
-  build:
+  lint:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    name: Lint
 
     steps:
       - uses: actions/checkout@v4
@@ -19,7 +18,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.4'
           extensions: dom, curl, libxml, mbstring, zip, pdo, sqlite, pdo_sqlite
           coverage: none
 
@@ -37,17 +36,22 @@ jobs:
       - name: Install dependencies
         run: composer install --no-interaction --prefer-dist --optimize-autoloader
 
-      - name: Upload vendor directory
-        uses: actions/upload-artifact@v4
-        with:
-          name: vendor
-          path: vendor/
-          retention-days: 1
+      - name: Run PHP-CS-Fixer
+        run: ./vendor/bin/php-cs-fixer fix --dry-run --diff
+
+      - name: Run PHPCS
+        continue-on-error: true
+        run: ./vendor/bin/phpcs src/ database/ tests/ config/
 
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    name: Test
+    name: Test (Livewire ${{ matrix.livewire }})
+
+    strategy:
+      fail-fast: true
+      matrix:
+        livewire: ['3.6', '4.0']
 
     steps:
       - uses: actions/checkout@v4
@@ -55,7 +59,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.4'
           extensions: dom, curl, libxml, mbstring, zip, pdo, sqlite, pdo_sqlite
           coverage: none
 
@@ -67,57 +71,21 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: ${{ runner.os }}-composer-
+          key: ${{ runner.os }}-composer-lw${{ matrix.livewire }}-${{ hashFiles('**/composer.json') }}
+          restore-keys: ${{ runner.os }}-composer-lw${{ matrix.livewire }}-
 
       - name: Install dependencies
         run: composer install --no-interaction --prefer-dist
 
+      - name: Install Livewire ${{ matrix.livewire }}
+        run: composer require livewire/livewire:"^${{ matrix.livewire }}" -W --no-interaction
+
       - name: Run Unit tests
         env:
           XDEBUG_MODE: off
-        run: php vendor/bin/pest tests/Unit --no-coverage
+        run: vendor/bin/pest tests/Unit --no-coverage
 
       - name: Run Feature tests
         env:
           XDEBUG_MODE: off
-        run: php vendor/bin/pest tests/Feature --no-coverage
-
-  release:
-    needs: test
-    runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v')
-    name: Create Release
-
-    permissions:
-      contents: write
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Extract release notes from CHANGELOG
-        id: changelog
-        run: |
-          VERSION=${GITHUB_REF#refs/tags/v}
-          echo "Extracting notes for version $VERSION"
-
-          if [ -f "CHANGELOG.md" ]; then
-            # Extract section for this version
-            NOTES=$(sed -n "/## \[$VERSION\]/,/## \[/p" CHANGELOG.md | sed '1d;$d' | sed '/^$/d')
-            if [ -z "$NOTES" ]; then
-              NOTES="Release $VERSION. See CHANGELOG.md for details."
-            fi
-          else
-            NOTES="Release $VERSION"
-          fi
-
-          # Save to file for multi-line support
-          echo "$NOTES" > release_notes.txt
-
-      - name: Create Release
-        uses: softprops/action-gh-release@v2
-        with:
-          body_path: release_notes.txt
-          generate_release_notes: false
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: vendor/bin/pest tests/Feature --no-coverage

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,39 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+    # Optional: Only run on specific file changes
+    # paths:
+    #   - "src/**/*.ts"
+    #   - "src/**/*.tsx"
+    #   - "src/**/*.js"
+    #   - "src/**/*.jsx"
+
+jobs:
+  claude-review:
+    if: false # Temporarily disabled while actively developing
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code Review
+        id: claude-review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
+          plugins: 'code-review@claude-code-plugins'
+          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # or https://code.claude.com/docs/en/cli-reference for available options
+

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -22,13 +22,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 1
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@99ca333651aa9a8becc279065fad21c4ef1c4494 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   claude-review:
-    if: false # Temporarily disabled while actively developing
+    if: ${{ vars.ENABLE_CLAUDE_REVIEW == 'true' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   claude-review:
-    if: ${{ vars.ENABLE_CLAUDE_REVIEW == 'true' }}
+    if: ${{ vars.ENABLE_CLAUDE_REVIEW == 'true' && github.event.pull_request.head.repo.fork == false }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,46 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: false # Temporarily disabled while actively developing
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+      actions: read # Required for Claude to read CI results on PRs
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          # This is an optional setting that allows Claude to read CI results on PRs
+          additional_permissions: |
+            actions: read
+
+          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
+          # prompt: 'Update the pull request description to include a summary of changes.'
+
+          # Optional: Add claude_args to customize behavior and configuration
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # or https://code.claude.com/docs/en/cli-reference for available options
+          # claude_args: '--allowed-tools Bash(gh pr:*)'
+

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -12,7 +12,18 @@ on:
 
 jobs:
   claude:
-    if: ${{ vars.ENABLE_CLAUDE_REVIEW == 'true' }}
+    if: ${{ vars.ENABLE_CLAUDE_REVIEW == 'true' && (
+      (github.event_name == 'issue_comment' &&
+       contains(github.event.comment.body, '@claude') &&
+       contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review_comment' &&
+       contains(github.event.comment.body, '@claude') &&
+       contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review' &&
+       contains(github.event.review.body, '@claude') &&
+       contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association)) ||
+      (github.event_name == 'issues' && github.event.action == 'assigned')
+    ) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -24,7 +24,8 @@ jobs:
           (github.event_name == 'pull_request_review' &&
            contains(github.event.review.body, '@claude') &&
            contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association)) ||
-          (github.event_name == 'issues' && github.event.action == 'assigned')
+          (github.event_name == 'issues' && github.event.action == 'assigned' &&
+           contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.sender.association))
         )
       }}
     runs-on: ubuntu-latest

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -12,18 +12,21 @@ on:
 
 jobs:
   claude:
-    if: ${{ vars.ENABLE_CLAUDE_REVIEW == 'true' && (
-      (github.event_name == 'issue_comment' &&
-       contains(github.event.comment.body, '@claude') &&
-       contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
-      (github.event_name == 'pull_request_review_comment' &&
-       contains(github.event.comment.body, '@claude') &&
-       contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
-      (github.event_name == 'pull_request_review' &&
-       contains(github.event.review.body, '@claude') &&
-       contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association)) ||
-      (github.event_name == 'issues' && github.event.action == 'assigned')
-    ) }}
+    if: >-
+      ${{
+        vars.ENABLE_CLAUDE_REVIEW == 'true' && (
+          (github.event_name == 'issue_comment' &&
+           contains(github.event.comment.body, '@claude') &&
+           contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+          (github.event_name == 'pull_request_review_comment' &&
+           contains(github.event.comment.body, '@claude') &&
+           contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+          (github.event_name == 'pull_request_review' &&
+           contains(github.event.review.body, '@claude') &&
+           contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association)) ||
+          (github.event_name == 'issues' && github.event.action == 'assigned')
+        )
+      }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -22,13 +22,13 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@99ca333651aa9a8becc279065fad21c4ef1c4494 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   claude:
-    if: false # Temporarily disabled while actively developing
+    if: ${{ vars.ENABLE_CLAUDE_REVIEW == 'true' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,103 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    name: Test before release
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          extensions: dom, curl, libxml, mbstring, zip, pdo, sqlite, pdo_sqlite
+          coverage: none
+
+      - name: Get Composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: ${{ runner.os }}-composer-
+
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist
+
+      - name: Run tests
+        env:
+          XDEBUG_MODE: off
+        run: vendor/bin/pest --no-coverage
+
+  release:
+    needs: test
+    runs-on: ubuntu-latest
+    name: Create Release
+
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Extract version from tag
+        id: version
+        run: echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+
+      - name: Extract release notes from CHANGELOG
+        id: changelog
+        run: |
+          VERSION=${{ steps.version.outputs.version }}
+          echo "Extracting notes for version $VERSION"
+
+          if [ ! -f "CHANGELOG.md" ]; then
+            echo "body=Release v$VERSION" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # Extract the section between this version header and the next version header
+          NOTES=$(awk -v ver="$VERSION" '
+            /^## \[/ {
+              if (found) exit
+              if (index($0, "[" ver "]")) { found=1; next }
+            }
+            found { print }
+          ' CHANGELOG.md)
+
+          # Remove leading/trailing blank lines
+          NOTES=$(echo "$NOTES" | sed '/./,$!d' | sed -e :a -e '/^\n*$/{$d;N;ba' -e '}')
+
+          if [ -z "$NOTES" ]; then
+            NOTES="Release v$VERSION — see CHANGELOG.md for details."
+          fi
+
+          # Write to file for multi-line support
+          echo "$NOTES" > release_notes.txt
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: v${{ steps.version.outputs.version }}
+          body_path: release_notes.txt
+          generate_release_notes: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Update Packagist
+        if: success()
+        run: |
+          curl -s -X POST \
+            "https://packagist.org/api/update-package?username=${{ secrets.PACKAGIST_USERNAME }}&apiToken=${{ secrets.PACKAGIST_API_TOKEN }}" \
+            -d "{\"repository\":{\"url\":\"https://github.com/${{ github.repository }}\"}}" \
+            -H "Content-Type: application/json"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
           echo "Extracting notes for version $VERSION"
 
           if [ ! -f "CHANGELOG.md" ]; then
-            echo "body=Release v$VERSION" >> $GITHUB_OUTPUT
+            echo "Release v$VERSION" > release_notes.txt
             exit 0
           fi
 
@@ -97,7 +97,7 @@ jobs:
       - name: Update Packagist
         if: success()
         run: |
-          curl -s -X POST \
+          curl --fail-with-body --show-error --retry 3 --retry-delay 2 --max-time 30 -X POST \
             "https://packagist.org/api/update-package?username=${{ secrets.PACKAGIST_USERNAME }}&apiToken=${{ secrets.PACKAGIST_API_TOKEN }}" \
             -d "{\"repository\":{\"url\":\"https://github.com/${{ github.repository }}\"}}" \
             -H "Content-Type: application/json"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,10 +12,10 @@ jobs:
     name: Test before release
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@8358ee0e2e8afe63c2fb8253d1d52085811ab1e5 # v2
         with:
           php-version: '8.4'
           extensions: dom, curl, libxml, mbstring, zip, pdo, sqlite, pdo_sqlite
@@ -26,7 +26,7 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache Composer dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
@@ -49,7 +49,7 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Extract version from tag
         id: version
@@ -86,7 +86,7 @@ jobs:
           echo "$NOTES" > release_notes.txt
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           name: v${{ steps.version.outputs.version }}
           body_path: release_notes.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0] - 2026-05-18
+
 ### Added
 
 - Initial release of the standalone Security Advanced Auth package, extracted from `artisanpack-ui/security` 1.x as part of the Security 2.0 package split.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,39 @@
 # ArtisanPack UI — Security Advanced Auth Changelog
 
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
 ## [Unreleased]
 
 ### Added
-- Initial package scaffold extracted from `package-blueprint`.
-- `artisanpack-ui/code-style` and `artisanpack-ui/code-style-pint` wired up for linting.
-- Source files migrated from `artisanpack-ui/security` 1.x covering WebAuthn, SSO, social login, biometric, device, and suspicious activity detection.
+
+- Initial release of the standalone Security Advanced Auth package, extracted from `artisanpack-ui/security` 1.x as part of the Security 2.0 package split.
+- **WebAuthn / FIDO2** — `WebAuthnManager` (577 lines) with registration + authentication options generation, response verification, and credential CRUD. Supports passkeys, security keys, and platform authenticators via the `WebAuthnInterface` contract.
+- **SSO** — `SsoManager` (302 lines) supporting SAML 2.0, OIDC, and LDAP. `SsoConfiguration` model for per-IdP definitions. SP metadata endpoint, SSO + SLO flows. `SsoUser` value object.
+- **Social authentication** — `SocialAuthManager` (363 lines) with 8 shipped OAuth providers (`AppleProvider`, `FacebookProvider`, `GitHubProvider`, `GoogleProvider`, `LinkedInProvider`, `MicrosoftProvider`, `GenericOidcProvider`, plus `AbstractOAuth2Provider` and `AbstractOidcProvider` base classes for custom providers). `SocialUser` value object, `SocialIdentity` model for link storage, account-linking helpers.
+- **Biometric authentication** — `BiometricManager` (196 lines) with the pluggable `BiometricProviderInterface`. `WebAuthnBiometricProvider` ships as the default implementation.
+- **Device fingerprinting** — `DeviceFingerprintService` for fingerprint generation, `UserDevice` model for known-device tracking, `DeviceFingerprint` model for raw fingerprint storage.
+- **Suspicious activity detection** — `SuspiciousActivityService` covering 11 auth-flow patterns (`brute_force`, `impossible_travel`, `anomalous_login`, `proxy_detected`, `tor_detected`, `datacenter_ip`, `multiple_failures`, `device_change`, `unusual_time`, `session_hijacking`, `credential_stuffing`).
+- **Livewire components** (5): `WebAuthnCredentialsManager`, `BiometricManager`, `DeviceManager`, `SocialAccountsManager`, `SuspiciousActivityList`. All with shipped Blade views in plain HTML + Tailwind, plus view-render smoke tests.
+- **HTTP controllers** (3): `SocialAuthController`, `SsoController`, `WebAuthnController`. Thin wrappers that delegate to the corresponding manager.
+- **Routes** (`routes/auth.php`): 12 endpoints covering social OAuth (redirect / callback / unlink), SSO (login / callback / logout / logout-callback / metadata), and WebAuthn (registration options / verify, authentication options / verify). Configurable prefix + per-group middleware.
+- **Eloquent models** (7): `DeviceFingerprint`, `SocialIdentity`, `SsoConfiguration`, `SsoIdentity`, `SuspiciousActivity`, `UserDevice`, `WebAuthnCredential`.
+- **Migrations** (7): full schema for the models above.
+- **Service contracts** (6): `BiometricProviderInterface`, `DeviceFingerprintInterface`, `SocialProviderInterface`, `SsoProviderInterface`, `SuspiciousActivityDetectorInterface`, `WebAuthnInterface`.
+- `SecurityAdvancedAuth` Facade and `security_advanced_auth()` helper.
+
+### Fixed
+
+- Closes [#12](https://github.com/ArtisanPack-UI/security-advanced-auth/issues/12) — wrote the 5 missing Livewire Blade views; without them every Livewire render threw `View not found` in production.
+- Closes [#13](https://github.com/ArtisanPack-UI/security-advanced-auth/issues/13) — shipped `routes/auth.php` with the 12 callback endpoints plus the 3 thin HTTP controllers. Without these, social OAuth / SSO / WebAuthn flows had no out-of-the-box wiring and consumers had to write controllers from scratch.
+- `SuspiciousActivityList` referenced model constants that don't exist (`TYPE_UNUSUAL_LOCATION`, `TYPE_UNUSUAL_DEVICE`, etc.). Replaced with the actual constants the model defines.
+- Service provider now publishes the views (tag: `security-advanced-auth-views`) so consumers can customize them.
+- Added `LivewireServiceProvider` to the test base case so Livewire component tests can mount.
+- Author email normalized to `support@artisanpackui.dev`.
+- License switched from GPL-3.0-or-later to MIT to match the rest of the ecosystem.
+
+### Removed
+
+- This package contains the enterprise auth content previously bundled in `artisanpack-ui/security` 1.x. See the [`artisanpack-ui/security` UPGRADE guide](https://github.com/ArtisanPack-UI/security/blob/main/UPGRADE.md) for migration instructions from 1.x.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to ArtisanPack UI
 
-As an open source project, ArtisanPack UI is open to contributions from everyone. You don't need to be a developer to contribute. Whether it's contributing code, writing documentation, testing the CMS or anything in between there's a place for you here to contribute.
+As an open source project, ArtisanPack UI is open to contributions from everyone. You don't need to be a developer to contribute. Whether it's contributing code, writing documentation, testing the packages, or anything in between, there's a place for you here to contribute.
 
 ## Table of Contents
 
@@ -21,8 +21,8 @@ In order to make this a best place for everyone to contribute, there are some ha
 
 * ArtisanPack UI is open to everyone no matter your race, ethnicity, gender, who you love, etc. In order to keep it that way, there's zero tolerance for any racist, misogynistic, xenophobic, bigoted, Zionist, antisemitic (yes, there is a difference), Islamophobic, etc. messages. This includes messages sent to a fellow contributor outside of this repository. In short, don't be a jerk. Failure to comply will result in a ban from the project.
 * Be respectful when communicating with fellow contributors.
-* Respect the decisions made for what to include in the CMS.
-* Work together to create the best possible content management system.
+* Respect the decisions made for what to include in the package.
+* Work together to create the best possible developer toolkit.
 
 ## Ways to Contribute
 
@@ -31,7 +31,7 @@ There are a ton of different ways to contribute to ArtisanPack UI even if you're
 * Write code for ArtisanPack UI core
 * Create plugins to extend ArtisanPack UI
 * Create themes to add designs for ArtisanPack UI
-* Test and report bugs found in the CMS
+* Test and report bugs found in the packages
 * Write documentation
 * Write tutorials and talk about ArtisanPack UI on your blog and/or social media profiles
 * Review pull/merge requests
@@ -44,7 +44,7 @@ There are a ton of different ways to contribute to ArtisanPack UI even if you're
 
 Before contributing, make sure you have:
 - Git installed on your machine
-- PHP 8.1 or higher
+- PHP 8.2 or higher
 - Composer
 - A GitLab, GitHub, or other Git hosting account
 
@@ -465,7 +465,7 @@ Similar to GitHub process:
 
 5. **Submit patch**
    - Create GitLab issue (no account needed via email)
-   - Or email patch to: [your email or link to contribution email]
+   - Or email patch to: support@artisanpackui.dev
    - Describe changes in issue/email
    - Attach `.patch` file
 
@@ -547,7 +547,7 @@ To keep things consistent across the code base, it's important to follow these n
 
 Follow conventional commit format:
 
-```
+```text
 type: Short description
 
 Longer description if needed.
@@ -565,7 +565,7 @@ Closes #123
 - `chore:` - Maintenance tasks
 
 **Examples:**
-```
+```text
 feat: Add dark mode support
 
 Implements dark mode theme with toggle in settings.
@@ -574,7 +574,7 @@ Includes proper color contrast for accessibility.
 Closes #456
 ```
 
-```
+```text
 fix: Resolve navigation menu overlap on mobile
 
 Menu was overlapping content on screens < 768px.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,10 +28,10 @@ In order to make this a best place for everyone to contribute, there are some ha
 
 There are a ton of different ways to contribute to ArtisanPack UI even if you're not a developer. Here are some (but not all) of the ways you can contribute to the project:
 
-* Write code for ArtisanPack UI core
-* Create plugins to extend ArtisanPack UI
-* Create themes to add designs for ArtisanPack UI
-* Test and report bugs found in the packages
+* Write code for the package
+* Build integrations or extensions on top of the package
+* Improve the package's tests, docs, and examples
+* Test and report bugs found in the package
 * Write documentation
 * Write tutorials and talk about ArtisanPack UI on your blog and/or social media profiles
 * Review pull/merge requests
@@ -196,7 +196,7 @@ Use this for most MRs. It includes:
 - Description of changes
 - Type of change (Bug fix, Feature, Enhancement, etc.)
 - Testing performed
-- **Accessibility tests** (required for all UI changes)
+- **Tests for the change** (unit and/or feature; required for code changes)
 - Tests added
 - Documentation updates
 - Pre-submission checklist
@@ -278,10 +278,9 @@ Labels that indicate importance:
 ### Area Labels (Where)
 
 Labels that indicate affected code area:
-- `Area::Frontend` - UI/client-side code
-- `Area::Backend` - Server/API code
-- `Area::Design` - Visual design work
-- `Area::Infrastructure` - DevOps/deployment
+- `Area::Core` - Core package logic
+- `Area::Integration` - Integration with Laravel framework / sibling packages
+- `Area::Infrastructure` - DevOps/deployment / CI
 - `Area::Testing` - Test-related work
 
 ### Special Labels
@@ -336,8 +335,8 @@ ArtisanPack UI is primarily hosted on GitLab, but you can contribute from any Gi
 
 2. **Clone your fork**
    ```bash
-   git clone git@gitlab.com:your-username/artisanpack-ui-package.git
-   cd artisanpack-ui-package
+   git clone git@gitlab.com:your-username/package-name.git
+   cd package-name
    ```
 
 3. **Add upstream remote**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,7 +78,7 @@ The template automatically applies these labels:
 
 **You should also add:**
 - `Priority::*` (Critical, High, Medium, or Low) if urgent
-- `Area::*` (Frontend, Backend, etc.) for the affected area
+- `Area::*` (Core, Integration, Infrastructure, Testing) for the affected area
 
 ### Feature Request Template
 
@@ -206,7 +206,7 @@ The template automatically applies:
 
 **You should also add:**
 - `Type::*` (Bug, Feature, Enhancement, etc.)
-- `Area::*` (Frontend, Backend, etc.)
+- `Area::*` (Core, Integration, Infrastructure, Testing)
 
 #### Release Template (Maintainers Only)
 

--- a/README.md
+++ b/README.md
@@ -1,38 +1,124 @@
 # ArtisanPack UI — Security Advanced Auth
 
-Enterprise authentication for Laravel: WebAuthn / FIDO2 passwordless auth, SSO (SAML / OIDC / LDAP), social login, biometric authentication, and device fingerprinting.
+Enterprise authentication for Laravel: WebAuthn / FIDO2 passwordless auth, SSO (SAML / OIDC / LDAP), social login across 8 providers, biometric authentication, device fingerprinting, and suspicious activity detection.
 
 This package is part of the **ArtisanPack UI Security 2.0** split — the enterprise-auth features previously bundled inside `artisanpack-ui/security` (1.x) live here in 2.0+.
 
-> **Status:** initial extraction. Source files are migrated from `artisanpack-ui/security` 1.x. Comprehensive test coverage migration is a follow-up — see open issues.
+## Features
 
-## Scope
-
-- WebAuthn / FIDO2 passwordless authentication
-- SSO providers (SAML, OIDC, LDAP)
-- Social login (OAuth)
-- Biometric authentication helpers
-- Device fingerprinting + suspicious activity detection
-- Livewire components: `WebAuthnCredentialsManager`, `BiometricManager`, `DeviceManager`, `SocialAccountsManager`, `SuspiciousActivityList`
+- **WebAuthn / FIDO2** (`WebAuthnManager`, 577 lines) — registration + authentication options, response verification, credential CRUD. Supports passkeys, security keys, and platform authenticators.
+- **SSO** (`SsoManager`, 302 lines) — SAML 2.0, OIDC, LDAP. Configurable per-IdP via `SsoConfiguration` model. SP metadata endpoint, single sign-on + single logout.
+- **Social authentication** (`SocialAuthManager`, 363 lines) — OAuth across 8 shipped providers (Apple, Facebook, GitHub, Google, LinkedIn, Microsoft, plus generic OIDC and OAuth2 abstract bases for custom providers).
+- **Biometric authentication** (`BiometricManager`) — pluggable provider model, `WebAuthnBiometricProvider` ships as the default.
+- **Device fingerprinting** (`DeviceFingerprintService`) — generates device fingerprints, tracks known / trusted devices, flags unknown devices.
+- **Suspicious activity detection** (`SuspiciousActivityService`) — auth-flow patterns (impossible travel, proxy detection, Tor detection, datacenter IPs, multiple failures, device changes, session hijacking).
+- **Livewire components** (5) — `WebAuthnCredentialsManager`, `BiometricManager`, `DeviceManager`, `SocialAccountsManager`, `SuspiciousActivityList` — all with shipped Blade views in plain HTML + Tailwind.
+- **HTTP controllers + routes** — bundled controllers and routes file with callback endpoints for social OAuth, SSO (SAML / OIDC), and WebAuthn ceremonies. Configurable prefix + middleware.
+- **Eloquent models** (7) — `DeviceFingerprint`, `SocialIdentity`, `SsoConfiguration`, `SsoIdentity`, `SuspiciousActivity`, `UserDevice`, `WebAuthnCredential`.
+- **Migrations** (7) — full schema for the above.
+- `SecurityAdvancedAuth` Facade and `security_advanced_auth()` helper.
 
 ## Installation
 
 ```bash
 composer require artisanpack-ui/security-advanced-auth
+php artisan migrate
 ```
+
+> The migrations create tables tied to the `users` table. Run Laravel's default migrations first.
+
+(Optional) Publish the config:
+
+```bash
+php artisan vendor:publish --tag=security-advanced-auth-config
+```
+
+(Optional) Publish the Livewire views for customization:
+
+```bash
+php artisan vendor:publish --tag=security-advanced-auth-views
+```
+
+## Quick start
+
+### Mount the Livewire components
+
+```blade
+<livewire:webauthn-credentials-manager />
+<livewire:biometric-manager />
+<livewire:device-manager />
+<livewire:social-accounts-manager />
+<livewire:suspicious-activity-list />
+```
+
+### Wire up a social provider
+
+```php
+use ArtisanPackUI\SecurityAdvancedAuth\Authentication\Social\SocialAuthManager;
+
+app( SocialAuthManager::class )->registerProvider( 'google', [
+    'client_id'     => env('GOOGLE_CLIENT_ID'),
+    'client_secret' => env('GOOGLE_CLIENT_SECRET'),
+    'redirect_uri'  => route('security-advanced-auth.social.callback', ['provider' => 'google']),
+] );
+```
+
+Users can now hit `/auth/social/google/redirect` to begin login. The callback at `/auth/social/google/callback` is wired automatically.
+
+### Wire up an SSO provider
+
+```php
+use ArtisanPackUI\SecurityAdvancedAuth\Models\SsoConfiguration;
+
+SsoConfiguration::create([
+    'slug'       => 'corp-saml',
+    'name'       => 'Corporate SAML',
+    'type'       => 'saml',
+    'config'     => [/* IdP-specific config */],
+    'is_enabled' => true,
+]);
+```
+
+Login URL: `/auth/sso/corp-saml/login`. SAML metadata at `/auth/sso/corp-saml/metadata`.
+
+### WebAuthn registration
+
+The Livewire `WebAuthnCredentialsManager` component handles the UI side. The host app's JS performs the actual WebAuthn ceremony via `navigator.credentials.create()` against options served by `POST /auth/webauthn/register/options`.
+
+## Documentation
+
+- [Documentation home](docs/home.md)
+- [Getting started](docs/getting-started.md)
+- [Installation](docs/installation.md)
+- [Usage](docs/usage.md)
+- [Advanced](docs/advanced.md)
+- [FAQ](docs/faq.md)
+- [Troubleshooting](docs/troubleshooting.md)
+- [Changelog](CHANGELOG.md)
+
+## Requirements
+
+- PHP 8.2+
+- Laravel 10 / 11 / 12
+- `livewire/livewire: ^3.6 | ^4.0` (for the 5 Livewire components)
+- A working `users` table (run Laravel's default migrations first)
+- Per-provider deps (e.g. SAML toolkit if you use SAML SSO — leave to the consumer to install)
 
 ## Sibling packages
 
 | Package | Scope |
 |---|---|
-| [`artisanpack-ui/security`](https://github.com/ArtisanPack-UI/security) | Core: input sanitization, output escaping, KSES, CSP, security headers |
-| [`artisanpack-ui/security-auth`](https://github.com/ArtisanPack-UI/security-auth) | 2FA, password security, account lockout, session management |
-| [`artisanpack-ui/rbac`](https://github.com/ArtisanPack-UI/rbac) | Roles, permissions, hierarchy, Blade directives, Gate integration |
-| [`artisanpack-ui/secure-uploads`](https://github.com/ArtisanPack-UI/secure-uploads) | File validation, malware scanning, secure storage |
+| [`artisanpack-ui/security`](https://github.com/ArtisanPack-UI/security) | Core: input sanitization, escaping, CSP, security headers |
+| [`artisanpack-ui/security-auth`](https://github.com/ArtisanPack-UI/security-auth) | 2FA, password complexity, account lockout, sessions |
+| [`artisanpack-ui/rbac`](https://github.com/ArtisanPack-UI/rbac) | Roles, permissions, Gate integration |
+| [`artisanpack-ui/secure-uploads`](https://github.com/ArtisanPack-UI/secure-uploads) | File validation, malware scanning, signed-URL serving |
 | [`artisanpack-ui/security-analytics`](https://github.com/ArtisanPack-UI/security-analytics) | Event logging, anomaly detection, SIEM, dashboards |
 | [`artisanpack-ui/compliance`](https://github.com/ArtisanPack-UI/compliance) | GDPR / CCPA / LGPD compliance tools |
-| [`artisanpack-ui/security-full`](https://github.com/ArtisanPack-UI/security-full) | Meta-package bundling all of the above |
+
+## License
+
+MIT — see [LICENSE](LICENSE).
 
 ## Contributing
 
-As an open source project, this package is open to contributions from anyone. Please [read through the contributing guidelines](CONTRIBUTING.md) to learn more about how you can contribute to this project.
+Please read the [contributing guidelines](CONTRIBUTING.md) before opening an issue or PR.

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ app( SocialAuthManager::class )->registerProvider( 'google', [
 ] );
 ```
 
-Users can now hit `/auth/social/google/redirect` to begin login. The callback at `/auth/social/google/callback` is wired automatically.
+With the default route prefix (`auth`), users can hit `/auth/social/google/redirect` to begin login. The callback at `/auth/social/google/callback` is wired automatically. The prefix is configurable via `artisanpack.security-advanced-auth.routes.prefix`; prefer the named routes (`security-advanced-auth.social.redirect`, `.callback`) when generating URLs.
 
 ### Wire up an SSO provider
 
@@ -79,7 +79,7 @@ SsoConfiguration::create([
 ]);
 ```
 
-Login URL: `/auth/sso/corp-saml/login`. SAML metadata at `/auth/sso/corp-saml/metadata`.
+With the default route prefix (`auth`), the login URL is `/auth/sso/corp-saml/login` and SAML metadata is at `/auth/sso/corp-saml/metadata`. Prefer the named routes (`security-advanced-auth.sso.login`, `.metadata`) when generating URLs — the prefix is configurable via `artisanpack.security-advanced-auth.routes.prefix`.
 
 ### WebAuthn registration
 

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ The Livewire `WebAuthnCredentialsManager` component handles the UI side. The hos
 
 | Package | Scope |
 |---|---|
+| [`artisanpack-ui/security-full`](https://github.com/ArtisanPack-UI/security-full) | Meta-package — pulls in the full security suite (all six packages below) in a single require |
 | [`artisanpack-ui/security`](https://github.com/ArtisanPack-UI/security) | Core: input sanitization, escaping, CSP, security headers |
 | [`artisanpack-ui/security-auth`](https://github.com/ArtisanPack-UI/security-auth) | 2FA, password complexity, account lockout, sessions |
 | [`artisanpack-ui/rbac`](https://github.com/ArtisanPack-UI/rbac) | Roles, permissions, Gate integration |

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "artisanpack-ui/security-advanced-auth",
   "description": "Enterprise authentication for Laravel — WebAuthn/FIDO2 passwordless auth, SSO (SAML/OIDC/LDAP), social login, biometric auth, and device fingerprinting.",
   "type": "library",
-  "license": "GPL-3.0-or-later",
+  "license": "MIT",
   "version": "0.1.0",
   "keywords": [
     "laravel",
@@ -33,7 +33,7 @@
   "authors": [
     {
       "name": "Jacob Martella",
-      "email": "me@jacobmartella.com"
+      "email": "support@artisanpackui.dev"
     }
   ],
   "require": {

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Enterprise authentication for Laravel — WebAuthn/FIDO2 passwordless auth, SSO (SAML/OIDC/LDAP), social login, biometric auth, and device fingerprinting.",
   "type": "library",
   "license": "MIT",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "keywords": [
     "laravel",
     "security",

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -1,0 +1,14 @@
+---
+title: Advanced
+---
+
+# Advanced
+
+Topics beyond day-to-day usage.
+
+## Topics
+
+- [Custom social providers](advanced/custom-social-providers.md) — add OAuth providers beyond the 8 shipped
+- [Custom SSO providers](advanced/custom-sso-providers.md) — bring your own SAML / OIDC / LDAP library
+- [Custom biometric providers](advanced/custom-biometric-providers.md) — platform-specific biometric SDKs
+- [Wiring a WebAuthn library](advanced/webauthn-library.md) — the package is library-agnostic; here's how to plug one in

--- a/docs/advanced/custom-biometric-providers.md
+++ b/docs/advanced/custom-biometric-providers.md
@@ -1,0 +1,122 @@
+---
+title: Custom Biometric Providers
+---
+
+# Custom Biometric Providers
+
+The shipped `WebAuthnBiometricProvider` covers browser-based biometric authentication via WebAuthn — which handles Touch ID, Face ID, Windows Hello, and Android fingerprint without any platform-specific code.
+
+When you need a platform-specific provider (typically inside a native mobile app wrapping your Laravel app), implement `BiometricProviderInterface`.
+
+## The contract
+
+```php
+namespace ArtisanPackUI\SecurityAdvancedAuth\Authentication\Contracts;
+
+interface BiometricProviderInterface
+{
+    public function getName(): string;
+    public function isAvailable( array $deviceInfo ): bool;
+    public function startEnrollment( $user, array $options ): array;
+    public function completeEnrollment( $user, array $response, string $challenge ): array;
+    public function startAuthentication( $user, array $options ): array;
+    public function verifyAuthentication( array $response, string $challenge ): array;
+}
+```
+
+`isAvailable($deviceInfo)` lets the provider decide based on what the client reports (platform, OS version, available authenticators).
+
+## Example: iOS LocalAuthentication wrapper
+
+For a wrapper around iOS LocalAuthentication used by a native iOS app:
+
+```php
+namespace App\Auth\Biometric;
+
+use ArtisanPackUI\SecurityAdvancedAuth\Authentication\Contracts\BiometricProviderInterface;
+
+class IosLocalAuthProvider implements BiometricProviderInterface
+{
+    public function getName(): string
+    {
+        return 'ios-local-auth';
+    }
+
+    public function isAvailable( array $deviceInfo ): bool
+    {
+        return ( $deviceInfo['platform'] ?? null ) === 'ios'
+            && ( $deviceInfo['supports_biometric'] ?? false );
+    }
+
+    public function startEnrollment( $user, array $options ): array
+    {
+        // Server side: generate a challenge, store keyed by the user
+        $challenge = bin2hex( random_bytes( 32 ) );
+
+        cache()->put( "biometric_enroll:{$user->id}", $challenge, now()->addMinutes(5) );
+
+        return [
+            'challenge'     => $challenge,
+            'user_id'       => (string) $user->id,
+            'attestation'   => 'direct',
+        ];
+    }
+
+    public function completeEnrollment( $user, array $response, string $challenge ): array
+    {
+        $expected = cache()->pull( "biometric_enroll:{$user->id}" );
+
+        if ( ! hash_equals( $expected ?? '', $challenge ) ) {
+            return ['success' => false, 'error' => 'Invalid challenge'];
+        }
+
+        // Verify the response signature, store the public key
+        // (Implementation depends on what the iOS app sends back)
+        $publicKey = $response['public_key'] ?? null;
+
+        if ( ! $publicKey ) {
+            return ['success' => false, 'error' => 'Missing public key'];
+        }
+
+        $user->biometric_public_key = $publicKey;
+        $user->biometric_enrolled_at = now();
+        $user->save();
+
+        return ['success' => true];
+    }
+
+    // ... rest of the interface
+}
+```
+
+## Registering
+
+```php
+use ArtisanPackUI\SecurityAdvancedAuth\Authentication\Biometric\BiometricManager;
+
+$this->app->afterResolving( BiometricManager::class, function ( BiometricManager $manager ): void {
+    $manager->extend( 'ios-local-auth', new IosLocalAuthProvider() );
+} );
+```
+
+Now usable:
+
+```php
+$manager->provider('ios-local-auth')->startAuthentication( $user, $deviceInfo );
+```
+
+## Default provider
+
+Set in config:
+
+```php
+'biometric' => ['default_provider' => 'webauthn'],   // or 'ios-local-auth' etc.
+```
+
+When the client doesn't specify a provider, `BiometricManager::startEnrollment()` uses the default.
+
+## Conventions
+
+- **Never trust client-asserted biometric state.** Even if a client claims biometric verification succeeded, your server must verify a cryptographic proof. Don't accept "I biometric-authed, trust me" — accept "here's a signed challenge response, verify the signature against the registered public key."
+- **Single-use challenges.** `cache()->pull()` over `cache()->get()` to prevent replay.
+- **Platform detection.** Use `isAvailable()` to opt out cleanly — better than failing mid-enrollment when the platform doesn't support what you registered.

--- a/docs/advanced/custom-social-providers.md
+++ b/docs/advanced/custom-social-providers.md
@@ -1,0 +1,111 @@
+---
+title: Custom Social Providers
+---
+
+# Custom Social Providers
+
+Add OAuth providers beyond the 8 shipped (Apple, Facebook, GitHub, Google, LinkedIn, Microsoft, generic OIDC, generic OAuth2).
+
+## Extending an abstract base
+
+Most custom providers can extend `AbstractOAuth2Provider` or `AbstractOidcProvider`:
+
+```php
+namespace App\Auth\Social;
+
+use ArtisanPackUI\SecurityAdvancedAuth\Authentication\Social\Providers\AbstractOAuth2Provider;
+
+class StripeProvider extends AbstractOAuth2Provider
+{
+    protected string $name = 'stripe';
+
+    protected function getAuthorizationUrl(): string
+    {
+        return 'https://connect.stripe.com/oauth/authorize';
+    }
+
+    protected function getTokenUrl(): string
+    {
+        return 'https://connect.stripe.com/oauth/token';
+    }
+
+    protected function getUserInfoUrl(): string
+    {
+        return 'https://api.stripe.com/v1/account';
+    }
+
+    protected function mapUserInfo( array $data ): array
+    {
+        return [
+            'id'    => $data['id'],
+            'email' => $data['email'] ?? null,
+            'name'  => $data['business_profile']['name'] ?? null,
+        ];
+    }
+}
+```
+
+The base class handles state validation, token exchange, and the user-info request — you provide the per-provider URLs and the user-info mapping.
+
+## Registering
+
+```php
+use ArtisanPackUI\SecurityAdvancedAuth\Authentication\Social\SocialAuthManager;
+use App\Auth\Social\StripeProvider;
+
+$this->app->afterResolving( SocialAuthManager::class, function ( SocialAuthManager $manager ): void {
+    $manager->extend( 'stripe', StripeProvider::class );
+} );
+```
+
+Now usable like any shipped provider:
+
+```php
+$manager->registerProvider( 'stripe', [
+    'client_id'     => env('STRIPE_CLIENT_ID'),
+    'client_secret' => env('STRIPE_CLIENT_SECRET'),
+    'redirect_uri'  => route('security-advanced-auth.social.callback', ['provider' => 'stripe']),
+] );
+```
+
+URLs: `/auth/social/stripe/redirect` and `/auth/social/stripe/callback`.
+
+## OIDC-compliant providers
+
+For providers that follow OIDC strictly, extend `AbstractOidcProvider` — you only need to supply the discovery URL:
+
+```php
+class AuthZeroProvider extends AbstractOidcProvider
+{
+    protected string $name = 'auth0';
+
+    protected function getDiscoveryUrl(): string
+    {
+        return "https://{$this->config['domain']}/.well-known/openid-configuration";
+    }
+}
+```
+
+The base class fetches the discovery document and configures itself from it.
+
+## Implementing from scratch
+
+For providers that don't fit OAuth2 / OIDC patterns, implement `SocialProviderInterface` directly:
+
+```php
+namespace ArtisanPackUI\SecurityAdvancedAuth\Authentication\Contracts;
+
+interface SocialProviderInterface
+{
+    public function getName(): string;
+    public function getRedirectUrl( array $options = [] ): string;
+    public function handleCallback( string $code, string $state ): SocialUser;
+    public function refreshToken( string $refreshToken ): array;
+}
+```
+
+## Conventions
+
+- **Validate state.** OAuth state is your CSRF defense — every callback handler must verify it matches what `getRedirectUrl()` stored. The abstract bases do this automatically.
+- **Map fields to a stable shape.** `SocialUser` has `id`, `email`, `name`, `avatar`, plus a free-form `raw` array. Always populate `id` (provider's stable user identifier); other fields are best-effort.
+- **Be resilient to user-info changes.** Providers occasionally restructure their user-info responses. Use null-safe access and `??` defaults in your `mapUserInfo()` implementation.

--- a/docs/advanced/custom-sso-providers.md
+++ b/docs/advanced/custom-sso-providers.md
@@ -1,0 +1,109 @@
+---
+title: Custom SSO Providers
+---
+
+# Custom SSO Providers
+
+`SsoManager` itself is concrete — what's pluggable is the per-type implementation. The shipped `SamlServiceProvider`, `OidcClient`, and `LdapAuthenticator` are configuration-driven wrappers around external libraries. To swap in your own library or a custom protocol, register a new type.
+
+## Adding a type
+
+```php
+use ArtisanPackUI\SecurityAdvancedAuth\Authentication\Sso\SsoManager;
+
+$this->app->afterResolving( SsoManager::class, function ( SsoManager $manager ): void {
+    $manager->extend( 'kerberos', \App\Auth\Sso\KerberosProvider::class );
+} );
+```
+
+The provider class must implement `SsoProviderInterface`:
+
+```php
+interface SsoProviderInterface
+{
+    public function getName(): string;
+    public function getLoginUrl( SsoConfiguration $config, array $options = [] ): string;
+    public function handleCallback( SsoConfiguration $config, Request $request ): SsoUser;
+    public function getLogoutUrl( SsoConfiguration $config, array $options = [] ): ?string;
+    public function handleLogout( SsoConfiguration $config, Request $request ): bool;
+    public function getMetadata( SsoConfiguration $config ): ?string;
+}
+```
+
+## Configurable IdP
+
+Each IdP is an `SsoConfiguration` row with `type`, `slug`, and a free-form `config` JSON. Your provider class reads the `config` to know IdP-specific details (endpoints, certificates, secrets).
+
+```php
+SsoConfiguration::create([
+    'slug'   => 'corp-kerberos',
+    'name'   => 'Corporate Kerberos',
+    'type'   => 'kerberos',
+    'config' => [
+        'realm'   => 'CORP.EXAMPLE.COM',
+        'kdc'     => 'krb.corp.example.com',
+        // ... whatever your provider needs
+    ],
+    'is_enabled' => true,
+]);
+```
+
+Login URL: `/auth/sso/corp-kerberos/login` automatically routes through your `KerberosProvider`.
+
+## Bring-your-own SAML library
+
+The shipped `SamlServiceProvider` is intentionally light. To use `onelogin/php-saml` (or any other SAML library):
+
+```php
+namespace App\Auth\Sso;
+
+use ArtisanPackUI\SecurityAdvancedAuth\Authentication\Contracts\SsoProviderInterface;
+use ArtisanPackUI\SecurityAdvancedAuth\Authentication\Sso\SsoUser;
+use ArtisanPackUI\SecurityAdvancedAuth\Models\SsoConfiguration;
+use Illuminate\Http\Request;
+use OneLogin\Saml2\Auth as Saml2Auth;
+
+class OneLoginSamlProvider implements SsoProviderInterface
+{
+    public function getName(): string { return 'saml'; }
+
+    public function handleCallback( SsoConfiguration $config, Request $request ): SsoUser
+    {
+        $auth = new Saml2Auth( $config->config );
+        $auth->processResponse();
+
+        if ( ! $auth->isAuthenticated() ) {
+            throw new \RuntimeException( 'SAML authentication failed: ' . implode( ', ', $auth->getErrors() ) );
+        }
+
+        return new SsoUser(
+            id: $auth->getNameId(),
+            email: $auth->getAttribute('email')[0] ?? null,
+            attributes: $auth->getAttributes(),
+        );
+    }
+
+    // ... other interface methods
+}
+```
+
+Register it as the new `saml` type (replaces the shipped one for that slug):
+
+```php
+$manager->extend( 'saml', OneLoginSamlProvider::class );
+```
+
+## Multiple IdPs of the same type
+
+The `slug` identifies the IdP, not the type. You can have 5 OIDC IdPs (`okta`, `auth0`, `azure-ad`, `keycloak`, `custom-oidc`) all using the same `OidcClient` provider — each with its own `SsoConfiguration` row carrying different config.
+
+The `slug` becomes the URL path: `/auth/sso/okta/login` vs `/auth/sso/auth0/login`.
+
+## Bypassing the bundled controllers
+
+If your SSO flow doesn't fit the standard redirect-callback pattern, disable the routes and wire your own controllers that call the manager directly:
+
+```php
+$loginUrl = app(SsoManager::class)->login('corp-okta');
+return redirect()->away($loginUrl);
+```

--- a/docs/advanced/webauthn-library.md
+++ b/docs/advanced/webauthn-library.md
@@ -1,0 +1,106 @@
+---
+title: Wiring a WebAuthn Library
+---
+
+# Wiring a WebAuthn Library
+
+The package's `WebAuthnManager` is intentionally library-agnostic — it defines the contract and the HTTP surface but leaves the actual WebAuthn cryptographic operations to a library of the consumer's choice. This page covers wiring two common options.
+
+## Why no built-in library?
+
+WebAuthn implementations are heavy, version-sensitive, and benefit from consumer control over the underlying library. The choices that fit production at one company don't always fit another. Forcing one would bloat installs and tie the package's version cadence to a third-party library's release cycle.
+
+## Option 1: `web-auth/webauthn-lib`
+
+The most popular PHP WebAuthn library. Install:
+
+```bash
+composer require web-auth/webauthn-lib
+```
+
+Wire a custom `WebAuthnManager` that delegates to it:
+
+```php
+namespace App\Auth;
+
+use ArtisanPackUI\SecurityAdvancedAuth\Authentication\WebAuthn\WebAuthnManager as BaseManager;
+use Webauthn\AttestationStatement\AttestationObjectLoader;
+use Webauthn\PublicKeyCredentialCreationOptions;
+use Webauthn\PublicKeyCredentialLoader;
+use Webauthn\Server;
+
+class WebAuthnLibManager extends BaseManager
+{
+    protected Server $server;
+
+    public function __construct(/* inject the library's Server + supporting services */)
+    {
+        // ... configure Server with RP, credential loader, validators
+    }
+
+    public function generateRegistrationOptions( $user, array $options = [] ): array
+    {
+        $publicKeyCredentialCreationOptions = $this->server->generatePublicKeyCredentialCreationOptions(
+            $this->buildPublicKeyCredentialUserEntity( $user ),
+            PublicKeyCredentialCreationOptions::ATTESTATION_CONVEYANCE_PREFERENCE_NONE,
+            $this->buildExcludeCredentials( $user ),
+        );
+
+        return $this->serializeOptions( $publicKeyCredentialCreationOptions );
+    }
+
+    public function verifyRegistration( $user, array $response, string $challenge ): array
+    {
+        // ... call $this->server->loadAndCheckAttestationResponse(...)
+    }
+
+    // ... rest
+}
+```
+
+Register your subclass:
+
+```php
+$this->app->singleton(
+    \ArtisanPackUI\SecurityAdvancedAuth\Authentication\WebAuthn\WebAuthnManager::class,
+    \App\Auth\WebAuthnLibManager::class,
+);
+```
+
+## Option 2: `pragmarx/webauthn-laravel`
+
+Higher-level Laravel-friendly wrapper. Install:
+
+```bash
+composer require pragmarx/webauthn-laravel
+```
+
+Wrap its Facade calls similarly — the same pattern: subclass `WebAuthnManager` and delegate.
+
+## Cross-package coordination
+
+The `BiometricManager`'s default `WebAuthnBiometricProvider` uses the same `WebAuthnManager` under the hood. Wire `WebAuthnManager` once; both surfaces benefit.
+
+## What you keep from the package
+
+Even when wiring your own WebAuthn library:
+
+- The Eloquent models (`WebAuthnCredential`) — stable schema, no library coupling
+- The shipped controllers and routes — they call `WebAuthnManager` interface methods, your override transparently replaces the implementation
+- The `WebAuthnCredentialsManager` Livewire component + view
+- The cross-package integration with `BiometricManager`
+
+Your custom code is concentrated in the manager subclass.
+
+## Reference Relying Party
+
+```php
+'webauthn' => [
+    'relying_party' => [
+        'id'   => env('WEBAUTHN_RP_ID'),
+        'name' => env('WEBAUTHN_RP_NAME'),
+    ],
+],
+```
+
+The RP ID must match the eTLD+1 your app runs on. For `app.example.com`, use `example.com` (so subdomains share credentials) or `app.example.com` (locked to that subdomain). Document the choice in your security runbook — it's hard to change later.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,84 @@
+---
+title: FAQ
+---
+
+# FAQ
+
+## Does this package require `artisanpack-ui/security`?
+
+No. Security Advanced Auth is standalone — it only pulls `artisanpack-ui/core` beyond standard Laravel.
+
+## Does it actually do WebAuthn / SAML / OAuth, or is it just glue?
+
+Both. The package defines the contracts, models, controllers, routes, and Livewire UI. The actual cryptographic / protocol heavy-lifting is delegated to whichever library the consumer wires in — this avoids forcing one heavy library on everyone. See [Wiring a WebAuthn library](advanced/webauthn-library.md) and [Custom SSO providers](advanced/custom-sso-providers.md) for the integration patterns.
+
+For the social OAuth providers (8 shipped), the package handles the full flow internally — no external library needed for the common providers.
+
+## Do I need both `security-auth` and `security-advanced-auth`?
+
+They're complementary:
+
+- `security-auth` covers everyday auth security — 2FA, password policy, lockout, sessions.
+- `security-advanced-auth` covers enterprise / passwordless — WebAuthn, SSO, social login, biometric.
+
+Most apps want both. The split exists so apps that only need one path don't get the dependencies of the other.
+
+## Can I use just one social provider?
+
+Yes. Register only the providers you actually use. The unregistered providers don't respond to the callback routes (they throw `RuntimeException`).
+
+## Can I disable the bundled routes?
+
+Yes — `'routes' => ['enabled' => false]` in config. Then wire your own controllers using the manager methods directly. Useful if you need bespoke URL structures or middleware combinations that don't fit the shipped routes.
+
+## How does device fingerprinting handle GDPR?
+
+The fingerprint hash + IP + UA are tied to the user via `UserDevice`. When the user is deleted, the rows go with them. The fingerprinting itself is for security purposes (account-takeover detection), which is generally permitted under GDPR's legitimate-interest basis. Document the practice in your privacy policy.
+
+For users who object specifically to fingerprinting, allow opt-out:
+
+```php
+if ( $user->privacy_settings['device_fingerprint'] ?? true ) {
+    $service->recordDevice( $user, $fingerprint, $request );
+}
+```
+
+## Why is suspicious activity detection in this package AND in security-analytics?
+
+Two different scopes:
+
+- **This package's `SuspiciousActivityService`** is auth-flow specific — impossible travel during login, proxy detection at sign-in time, etc. Tightly coupled to the auth event stream.
+- **`security-analytics`'s service** is a higher-level audit surface — any activity, not just auth. Includes a broader catalogue of patterns.
+
+Both can coexist. The migration table-name conflict (both want `suspicious_activities`) is tracked as a separate issue — for now, install only one or skip the duplicate migration.
+
+## What if a user loses their WebAuthn device?
+
+The user needs an alternative recovery path — they can't authenticate with the lost device anymore. Common patterns:
+
+- Have multiple credentials registered (security key + platform passkey)
+- Pair with `security-auth`'s 2FA recovery codes
+- Account recovery flow with identity verification
+
+Don't make WebAuthn the only credential type. Recovery is a deliberate UX decision.
+
+## Can I use this with Laravel Sanctum / Passport?
+
+Yes. The package's flows are session-based (WebAuthn ceremonies, OAuth callbacks). Once the user is authenticated, your normal Sanctum / Passport token flow continues. For pure API auth without sessions, you'd need to wire WebAuthn challenges directly into your token-issuance endpoint.
+
+## Why are the migrations risky to run alongside security-analytics?
+
+Both packages ship a `create_suspicious_activities_table` migration that creates the same table. Run one of them or skip the duplicate. Long-term fix: both migrations get `Schema::hasTable()` guards.
+
+## Where do I configure the WebAuthn Relying Party?
+
+```php
+'webauthn' => [
+    'relying_party' => [
+        'id'   => 'app.example.com',
+        'name' => 'My App',
+    ],
+],
+```
+
+The RP ID is locked at credential registration time — changing it invalidates existing credentials. Pick deliberately; document the choice.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,82 @@
+---
+title: Getting Started
+---
+
+# Getting Started
+
+Five minutes from install to a working social login + Livewire dashboard.
+
+## 1. Install
+
+```bash
+composer require artisanpack-ui/security-advanced-auth
+php artisan migrate
+```
+
+> The migrations create 7 tables tied to the `users` table. Run Laravel's default migrations first.
+
+## 2. Register a social provider
+
+In a service provider (e.g. `AppServiceProvider::boot()`):
+
+```php
+use ArtisanPackUI\SecurityAdvancedAuth\Authentication\Social\SocialAuthManager;
+
+app( SocialAuthManager::class )->registerProvider( 'google', [
+    'client_id'     => env('GOOGLE_CLIENT_ID'),
+    'client_secret' => env('GOOGLE_CLIENT_SECRET'),
+    'redirect_uri'  => route('security-advanced-auth.social.callback', ['provider' => 'google']),
+] );
+```
+
+## 3. Add the redirect button
+
+```blade
+<a href="{{ route('security-advanced-auth.social.redirect', ['provider' => 'google']) }}">
+    Sign in with Google
+</a>
+```
+
+The user clicks → Google auth screen → Google redirects back to the bundled callback → user is logged in.
+
+## 4. Mount the Livewire components
+
+```blade
+<livewire:webauthn-credentials-manager />
+<livewire:biometric-manager />
+<livewire:device-manager />
+<livewire:social-accounts-manager />
+<livewire:suspicious-activity-list />
+```
+
+Drop these on your user's security settings page.
+
+## 5. (Optional) Wire up SSO
+
+```php
+use ArtisanPackUI\SecurityAdvancedAuth\Models\SsoConfiguration;
+
+SsoConfiguration::create([
+    'slug'       => 'corp-okta',
+    'name'       => 'Corporate Okta',
+    'type'       => 'oidc',
+    'config'     => [
+        'discovery_url' => 'https://corp.okta.com/.well-known/openid-configuration',
+        'client_id'     => env('OKTA_CLIENT_ID'),
+        'client_secret' => env('OKTA_CLIENT_SECRET'),
+    ],
+    'is_enabled' => true,
+]);
+```
+
+Login URL: `/auth/sso/corp-okta/login`.
+
+## 6. (Optional) Add a WebAuthn passkey
+
+The Livewire `WebAuthnCredentialsManager` handles the UI. The actual WebAuthn ceremony is browser JS — host app calls `navigator.credentials.create()` against the options endpoint at `POST /auth/webauthn/register/options`.
+
+## Next steps
+
+- [Usage](usage.md) — per-subsystem reference (WebAuthn, SSO, social, biometric, device, suspicious activity)
+- [Advanced](advanced.md) — extending providers, custom flows
+- [Installation](installation.md) — full config reference

--- a/docs/home.md
+++ b/docs/home.md
@@ -1,0 +1,38 @@
+---
+title: ArtisanPack UI Security Advanced Auth Documentation
+---
+
+# ArtisanPack UI Security Advanced Auth
+
+Enterprise authentication for Laravel: WebAuthn / FIDO2, SSO (SAML / OIDC / LDAP), social login, biometric authentication, device fingerprinting, and auth-flow suspicious activity detection.
+
+This package is part of the **ArtisanPack UI Security 2.0** split.
+
+## What's in this package
+
+- **WebAuthn / FIDO2** — passkey + security-key authentication
+- **SSO** — SAML 2.0, OIDC, LDAP with bundled callback routes + controllers
+- **Social authentication** — 8 OAuth providers (Apple, Facebook, GitHub, Google, LinkedIn, Microsoft, generic OIDC + OAuth2 abstracts)
+- **Biometric** — pluggable provider model
+- **Device fingerprinting + trusted devices**
+- **Suspicious activity detection** for auth-flow patterns
+- **5 Livewire components** + 12 callback routes ship out of the box
+
+## Documentation map
+
+- [Getting Started](getting-started.md) — 5-minute install + first social provider
+- [Installation](installation.md)
+- [Usage](usage.md) — per-subsystem reference
+- [Advanced](advanced.md) — extending providers, custom flows
+- [FAQ](faq.md)
+- [Troubleshooting](troubleshooting.md)
+
+## Related packages
+
+| Package | Scope |
+|---|---|
+| [`artisanpack-ui/security`](https://github.com/ArtisanPack-UI/security) | Core: sanitization, escaping, CSP, security headers |
+| [`artisanpack-ui/security-auth`](https://github.com/ArtisanPack-UI/security-auth) | 2FA, password complexity, account lockout |
+| [`artisanpack-ui/rbac`](https://github.com/ArtisanPack-UI/rbac) | Roles, permissions, Gate integration |
+| [`artisanpack-ui/secure-uploads`](https://github.com/ArtisanPack-UI/secure-uploads) | File validation, malware scanning |
+| [`artisanpack-ui/security-analytics`](https://github.com/ArtisanPack-UI/security-analytics) | Event logging, anomaly detection, SIEM, dashboards |

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,50 @@
+---
+title: Installation
+---
+
+# Installation
+
+## Install via Composer
+
+```bash
+composer require artisanpack-ui/security-advanced-auth
+```
+
+## Run migrations
+
+```bash
+php artisan migrate
+```
+
+Creates 7 tables: `social_identities`, `sso_configurations`, `sso_identities`, `webauthn_credentials`, `user_devices`, `device_fingerprints`, `suspicious_activities`.
+
+> Most migrations reference `users(id)`. Run Laravel's default migrations first.
+
+## (Optional) Publish the config
+
+```bash
+php artisan vendor:publish --tag=security-advanced-auth-config
+```
+
+## (Optional) Publish the Livewire views
+
+```bash
+php artisan vendor:publish --tag=security-advanced-auth-views
+```
+
+Customize the published views at `resources/views/vendor/security-advanced-auth/livewire/*.blade.php`.
+
+## Disable the bundled routes
+
+If you want to wire your own controllers:
+
+```php
+'routes' => ['enabled' => false],
+```
+
+The 12 callback endpoints stop registering. You then need to wire `redirect`, `callback`, `unlink`, etc. yourself by calling the managers directly.
+
+## Deeper topics
+
+- [Requirements](installation/requirements.md)
+- [Configuration](installation/configuration.md)

--- a/docs/installation/configuration.md
+++ b/docs/installation/configuration.md
@@ -72,8 +72,9 @@ Per-IdP config lives in the `sso_configurations` table — DB-driven so it can b
 
 ```php
 'device_fingerprint' => [
-    'enabled'      => true,
-    'trust_period' => 90,  // days a device stays trusted after a successful login
+    'enabled'                 => true,
+    'trust_period'            => 90,   // days a device stays trusted after a successful login
+    'auto_trust_after_logins' => null, // or integer N — auto-trust after N successful logins from the same fingerprint
 ],
 ```
 

--- a/docs/installation/configuration.md
+++ b/docs/installation/configuration.md
@@ -1,0 +1,90 @@
+---
+title: Configuration
+---
+
+# Configuration
+
+Publish the config:
+
+```bash
+php artisan vendor:publish --tag=security-advanced-auth-config
+```
+
+Lives at `config/artisanpack/security-advanced-auth.php`.
+
+## `routes`
+
+```php
+'routes' => [
+    'enabled'  => env('SECURITY_ADVANCED_AUTH_ROUTES_ENABLED', true),
+    'prefix'   => env('SECURITY_ADVANCED_AUTH_ROUTES_PREFIX', 'auth'),
+    'social'   => ['middleware' => ['web']],
+    'sso'      => ['middleware' => ['web']],
+    'webauthn' => ['middleware' => ['api']],
+],
+```
+
+Disable the routes wholesale or per-group, swap the prefix, customize middleware (e.g. add CSRF exemption for the SAML ACS endpoint).
+
+## `webauthn`
+
+```php
+'webauthn' => [
+    'relying_party' => [
+        'id'   => env('WEBAUTHN_RP_ID', parse_url(env('APP_URL'), PHP_URL_HOST)),
+        'name' => env('WEBAUTHN_RP_NAME', config('app.name')),
+    ],
+    'passwordless_enabled'      => true,
+    'max_credentials_per_user'  => 10,
+],
+```
+
+## `social`
+
+```php
+'social' => [
+    'redirect_after_login' => '/dashboard',
+    'allowed_email_domains' => null,   // null = any; or ['example.com', 'mycompany.com']
+],
+```
+
+Per-provider config (client_id / secret / etc.) is registered via `SocialAuthManager::registerProvider()` from a service provider, not from config — provider credentials are usually per-environment env vars.
+
+## `sso`
+
+```php
+'sso' => [
+    'redirect_after_login' => '/dashboard',
+],
+```
+
+Per-IdP config lives in the `sso_configurations` table — DB-driven so it can be edited at runtime via an admin UI.
+
+## `biometric`
+
+```php
+'biometric' => [
+    'default_provider' => 'webauthn',
+],
+```
+
+## `device_fingerprint`
+
+```php
+'device_fingerprint' => [
+    'enabled'      => true,
+    'trust_period' => 90,  // days a device stays trusted after a successful login
+],
+```
+
+## `suspicious_activity`
+
+```php
+'suspicious_activity' => [
+    'enabled'                => true,
+    'impossible_travel_kmh'  => 800,
+    'datacenter_check'       => true,
+    'tor_check'              => true,
+    'auto_lock_threshold'    => 'high',  // severity at which to auto-lock the account
+],
+```

--- a/docs/installation/requirements.md
+++ b/docs/installation/requirements.md
@@ -1,0 +1,41 @@
+---
+title: Requirements
+---
+
+# Requirements
+
+## PHP
+
+- PHP 8.2+
+
+## Laravel
+
+- Laravel 10 / 11 / 12
+
+## Composer dependencies (pulled in automatically)
+
+- `artisanpack-ui/core: ^1.0`
+
+## Optional dependencies
+
+- **`livewire/livewire: ^3.6 | ^4.0`** — only required for the 5 Livewire components. The manager classes (`WebAuthnManager`, `SsoManager`, `SocialAuthManager`, `BiometricManager`, `DeviceFingerprintService`, `SuspiciousActivityService`) work without Livewire.
+- **`web-auth/webauthn-lib`** or similar — `WebAuthnManager` is provider-agnostic; bring whichever WebAuthn library fits your stack and wire it in.
+- **SAML / OIDC toolkit per IdP** — `SsoManager` is configuration-driven; install the underlying SAML or OIDC library that matches your IdP.
+- **`socialiteproviders/*` packages** — `SocialAuthManager`'s provider list can lean on Socialite providers for the OAuth dance.
+
+The package is intentionally light on hard deps so consumers pick the underlying libraries that fit their environment.
+
+## Database
+
+Any Eloquent-supported driver. Migrations reference `users(id)` — the standard Laravel `users` table must exist.
+
+## External services (per-provider)
+
+| Subsystem | Service |
+|---|---|
+| Social OAuth | Provider credentials (client ID + secret) per registered provider |
+| SAML SSO | IdP metadata or per-app federation config |
+| OIDC SSO | IdP discovery URL + client credentials |
+| LDAP SSO | LDAP server connection details |
+| WebAuthn | None — runs against the host app's domain as the Relying Party |
+| Biometric | Browser support (WebAuthn-backed by default) |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,97 @@
+---
+title: Troubleshooting
+---
+
+# Troubleshooting
+
+## `View [security-advanced-auth::livewire.*] not found`
+
+A 0.x bug — the 5 Livewire components didn't have shipped views. Fixed in v1.0. Update if you're on a pre-1.0 build.
+
+## `Class 'OneLogin\Saml2\Auth' not found` / similar for OIDC / LDAP
+
+The package ships interface-level for SSO. You need to install the underlying library (`onelogin/php-saml`, `web-token/jwt-framework`, `directorytree/ldaprecord-laravel`) and wire it into a custom SSO provider. See [Custom SSO providers](advanced/custom-sso-providers.md).
+
+## WebAuthn registration silently fails
+
+Three common causes:
+
+1. **RP ID mismatch.** The Relying Party ID must match your app's domain (or a parent eTLD+1). If you registered against `example.com` and the user visits `app.example.com`, the credential's RP ID has to match. Verify via browser DevTools — the WebAuthn error usually includes the RP ID it tried.
+2. **HTTPS required.** Browsers refuse WebAuthn over HTTP except for `localhost`. Make sure dev / staging / production all use HTTPS.
+3. **No WebAuthn library wired.** The package ships interface-only — see [Wiring a WebAuthn library](advanced/webauthn-library.md).
+
+## OAuth callback returns 419 (CSRF / expired)
+
+The `state` parameter validation in `SocialAuthController::callback()` checks session state. If sessions are misconfigured (e.g. cross-domain cookies, missing `SESSION_DOMAIN`), the state lookup fails. Verify your session driver + cookie config across the redirect.
+
+## SAML ACS returns 419
+
+SAML POST-from-IdP is rejected by Laravel's CSRF middleware. Exempt the path:
+
+```php
+// app/Http/Middleware/VerifyCsrfToken.php
+protected $except = [
+    'auth/sso/*/callback',
+];
+```
+
+## OIDC callback returns 500 on first login
+
+Usually the first-time user creation fails because your User model has required fields that aren't supplied by the IdP. Options:
+
+1. Add defaults to the User model's `$attributes` array
+2. Override `SsoManager::findOrCreateUser()` (subclass + rebind) to supply the missing fields
+3. Switch to a "link-only" flow — only allow SSO for users who already exist
+
+## Tests fail with `no such table: users`
+
+Same fix as security-auth:
+
+```php
+beforeEach( function (): void {
+    if ( ! Schema::hasTable( 'users' ) ) {
+        Schema::create( 'users', function ( Blueprint $table ): void {
+            $table->id();
+            $table->string( 'name' );
+            $table->string( 'email' )->unique();
+            $table->timestamp( 'email_verified_at' )->nullable();
+            $table->string( 'password' );
+            $table->rememberToken();
+            $table->timestamps();
+        } );
+    }
+    $this->artisan( 'migrate' );
+} );
+```
+
+The package's `tests/Feature/Livewire/ComponentRenderTest.php` uses this pattern — copy from there.
+
+## `Class [livewire] does not exist` in tests
+
+The base test case loads `LivewireServiceProvider`. If you've subclassed `TestCase` and overridden `getPackageProviders()`, make sure you still include it.
+
+## Suspicious-activity migration conflicts with security-analytics
+
+Both packages ship a migration creating `suspicious_activities`. Workarounds:
+
+- Install only one
+- Or skip the duplicate by listing it in `--exclude` of the migration command
+- Or guard the migration with `Schema::hasTable()` (long-term fix tracked as an issue)
+
+## Routes don't show up
+
+Check three things:
+
+1. `'routes.enabled' => true` in config (default `true`)
+2. `php artisan route:list --name=security-advanced-auth` shows the registered routes — if not, the package's service provider isn't loading. Check `composer dump-autoload` and that `vendor/autoload.php` is fresh.
+3. Conflict with another route at the same path — Laravel registers in order; if your app routes claimed `/auth/social/*` first, theirs win.
+
+## Still stuck?
+
+Open an issue at https://github.com/ArtisanPack-UI/security-advanced-auth/issues with:
+
+- PHP and Laravel versions
+- Which subsystem (WebAuthn, SSO, social, biometric, device, suspicious activity)
+- Which library you've wired (if applicable) and its version
+- The exact error + minimal reproduction
+- Config with secrets redacted

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,18 @@
+---
+title: Usage
+---
+
+# Usage
+
+Per-subsystem reference.
+
+## Topics
+
+- [WebAuthn / FIDO2](usage/webauthn.md) — registration + authentication, credential management
+- [SSO](usage/sso.md) — SAML / OIDC / LDAP setup, callback flow, SP metadata
+- [Social authentication](usage/social.md) — 8 shipped providers, OAuth callback flow, account linking
+- [Biometric](usage/biometric.md) — biometric provider model, enrollment flow
+- [Device fingerprinting](usage/device-fingerprinting.md) — known devices, trust period
+- [Suspicious activity](usage/suspicious-activity.md) — 11 auth-flow patterns
+- [Routes](usage/routes.md) — all 12 shipped endpoints
+- [Livewire components](usage/livewire-components.md) — 5 shipped components + view customization

--- a/docs/usage/biometric.md
+++ b/docs/usage/biometric.md
@@ -1,0 +1,69 @@
+---
+title: Biometric Authentication
+---
+
+# Biometric Authentication
+
+`BiometricManager` is a thin orchestrator over pluggable `BiometricProviderInterface` implementations. The shipped `WebAuthnBiometricProvider` is the default — it uses WebAuthn under the hood, which is the standard browser-native biometric API.
+
+## API
+
+```php
+use ArtisanPackUI\SecurityAdvancedAuth\Authentication\Biometric\BiometricManager;
+
+$manager = app( BiometricManager::class );
+
+// Discover what's available on the user's device
+$available = $manager->isAvailable( $deviceInfo );  // bool
+$providers = $manager->getAvailableProviders( $deviceInfo );
+
+// Enrollment
+$options = $manager->startEnrollment( $user, $deviceInfo, [/* options */] );
+// (client runs the biometric prompt, returns response)
+$result  = $manager->completeEnrollment( $user, 'webauthn', $response, $challenge );
+
+// Authentication
+$options = $manager->startAuthentication( $user, $deviceInfo );
+// (client prompts user for biometric, returns response)
+$result  = $manager->verifyAuthentication( 'webauthn', $response, $challenge );
+```
+
+## Using the Livewire component
+
+```blade
+<livewire:biometric-manager />
+```
+
+Shows registered biometrics, an "Add biometric" button, and delete controls. The host app's JS handles the actual biometric prompt — the component dispatches `start-biometric-enrollment` with the options payload, host JS calls `navigator.credentials.create()`, then dispatches `completeEnrollment` back.
+
+## Provider model
+
+The package ships `WebAuthnBiometricProvider`. Add platform-specific providers by implementing `BiometricProviderInterface`:
+
+```php
+namespace App\Auth\Biometric;
+
+use ArtisanPackUI\SecurityAdvancedAuth\Authentication\Contracts\BiometricProviderInterface;
+
+class FaceIdProvider implements BiometricProviderInterface
+{
+    public function isAvailable( array $deviceInfo ): bool { /* ... */ }
+    public function startEnrollment( $user, array $options ): array { /* ... */ }
+    public function completeEnrollment( $user, array $response, string $challenge ): array { /* ... */ }
+    public function startAuthentication( $user, array $options ): array { /* ... */ }
+    public function verifyAuthentication( array $response, string $challenge ): array { /* ... */ }
+    public function getName(): string { return 'face-id'; }
+}
+```
+
+Register:
+
+```php
+$manager->extend( 'face-id', new FaceIdProvider() );
+```
+
+## Use cases
+
+- **WebAuthn-backed biometric is the right default.** It uses the device's native biometric (Touch ID, Face ID, Windows Hello, Android fingerprint) without needing platform-specific code.
+- **Custom biometric providers** make sense for native mobile apps wrapping your Laravel app — pair with platform-specific biometric SDKs (iOS LocalAuthentication, Android BiometricPrompt).
+- Don't roll your own biometric crypto. Either use WebAuthn or use a vetted platform SDK; never invent.

--- a/docs/usage/device-fingerprinting.md
+++ b/docs/usage/device-fingerprinting.md
@@ -1,0 +1,83 @@
+---
+title: Device Fingerprinting
+---
+
+# Device Fingerprinting
+
+`DeviceFingerprintService` generates per-device fingerprints, tracks known / trusted devices, and flags unknown devices. Pair with the `DeviceManager` Livewire component for the UI.
+
+## How fingerprinting works
+
+The fingerprint is a stable hash over a combination of:
+
+- User-Agent string
+- Accept-Language header
+- Screen resolution (when JS-provided)
+- Color depth (when JS-provided)
+- Timezone offset (when JS-provided)
+- Canvas / WebGL fingerprint (when JS-provided)
+
+The hash is stable within a browser but distinct across devices. Not unique enough to be reliably privacy-invasive (multiple users on the same browser hash identically), but unique enough to detect "user signed in from a never-before-seen device."
+
+## API
+
+```php
+use ArtisanPackUI\SecurityAdvancedAuth\Authentication\Device\DeviceFingerprintService;
+
+$service = app( DeviceFingerprintService::class );
+
+// Generate from the current request
+$fingerprint = $service->fingerprint( $request, $clientHints = [] );
+
+// Look up
+$device = $service->findUserDevice( $user, $fingerprint );  // ?UserDevice
+
+// Record on successful login
+$device = $service->recordDevice( $user, $fingerprint, $request );
+
+// Trust / untrust
+$service->trustDevice( $device );
+$service->untrustDevice( $device );
+
+// Revoke (deletes the row — user has to re-establish trust on next login)
+$service->revokeDevice( $device );
+```
+
+## Trust period
+
+New devices start untrusted. Use `DeviceManager` to let users mark a device as trusted from their security settings page. Or auto-trust after N successful logins from the same fingerprint:
+
+```php
+'device_fingerprint' => [
+    'auto_trust_after_logins' => 3,
+],
+```
+
+## Per-app integration
+
+The service is data-only — it doesn't gate access. To gate access on device trust:
+
+```php
+$fingerprint = $service->fingerprint( $request, $clientHints );
+$device = $service->findUserDevice( $user, $fingerprint );
+
+if ( ! $device || ! $device->trusted ) {
+    // Require step-up authentication, additional verification, or notify the user
+}
+```
+
+Or wire a middleware that does this check on protected routes.
+
+## Livewire UI
+
+```blade
+<livewire:device-manager />
+```
+
+Lists known devices with trust state, IP, last seen, OS / browser. Trust / revoke buttons per device, plus "revoke all other devices."
+
+## Privacy considerations
+
+Device fingerprints are a soft form of cross-session identifier. In jurisdictions with strict privacy laws (EU, California), document fingerprinting in your privacy policy and offer opt-out. Fingerprinting for security purposes (fraud / account takeover detection) is generally permissible — fingerprinting for marketing / tracking is not.
+
+The `UserDevice` row stores: fingerprint hash, IP at registration, user agent, OS, browser, last-seen-at. No raw biometric data, no precise geolocation. Easy to comply with subject access / erasure requests — delete the user, the rows go with them.

--- a/docs/usage/livewire-components.md
+++ b/docs/usage/livewire-components.md
@@ -1,0 +1,74 @@
+---
+title: Livewire Components
+---
+
+# Livewire Components
+
+Five components ship with Blade views in plain HTML + Tailwind. Drop them on the user's security settings page or wherever makes sense for your UX.
+
+## `<livewire:webauthn-credentials-manager />`
+
+Lists registered passkeys / security keys. "Add passkey" button opens an enrollment modal; "Delete" with confirmation per credential.
+
+Public state:
+- `credentials` (array) — list of registered credentials
+- `showRegisterModal` (bool)
+- `newCredentialName` (string)
+- `registrationOptions` (array | null) — options the host JS uses for `navigator.credentials.create()`
+
+Browser-side JS responsibilities:
+- Listen for `start-webauthn-registration`
+- Call `navigator.credentials.create({publicKey: options})`
+- Dispatch `completeRegistration` with the response
+
+## `<livewire:biometric-manager />`
+
+Same shape as the WebAuthn component but for biometric authenticators (Touch ID, Face ID, Windows Hello, Android fingerprint). The default `WebAuthnBiometricProvider` makes biometric registration work through WebAuthn under the hood.
+
+Public state:
+- `biometrics` (array)
+- `showEnrollModal` (bool)
+- `enrollmentOptions` (array | null)
+- `platformSupported` (bool) — set to `false` to disable the "Add biometric" button on devices without biometric support
+
+## `<livewire:device-manager />`
+
+Lists known devices with trust / revoke controls. "Revoke all other devices" button.
+
+Public state:
+- `devices` (array) — `[{id, name, browser, os, ip_address, last_seen_at, trusted}, ...]`
+- `currentDeviceId` (string | null) — highlights the current device
+- `revokingDeviceId` (string | null) — staging state for confirmation
+
+## `<livewire:social-accounts-manager />`
+
+Lists linked OAuth providers + "available to link" buttons.
+
+Public state:
+- `linkedAccounts` (array) — `[{provider, provider_user_email, linked_at}, ...]`
+- `availableProviders` (array of strings) — providers not yet linked
+- `unlinkingProvider` (string | null) — staging state for confirmation
+
+## `<livewire:suspicious-activity-list />`
+
+Filterable list of suspicious activity for the user (or all users for admins with the appropriate permission).
+
+Public state:
+- `filterSeverity` (string)
+- `filterType` (string)
+
+## Customizing views
+
+Publish:
+
+```bash
+php artisan vendor:publish --tag=security-advanced-auth-views
+```
+
+Publishes the views to `resources/views/vendor/security-advanced-auth/livewire/*.blade.php`. Laravel resolves overrides before the package defaults.
+
+Common customizations:
+- Wrap in your design-system components
+- Swap modals for a richer modal library
+- Add platform-specific icons (Apple, Google, etc. logos for the social manager)
+- Customize copy / translations

--- a/docs/usage/routes.md
+++ b/docs/usage/routes.md
@@ -1,0 +1,80 @@
+---
+title: Routes
+---
+
+# Routes
+
+`routes/auth.php` registers 12 endpoints across three groups: social OAuth, SSO, and WebAuthn. Configurable prefix + per-group middleware.
+
+## Social OAuth
+
+| Method | Path | Name | Purpose |
+|---|---|---|---|
+| GET | `/auth/social/{provider}/redirect` | `security-advanced-auth.social.redirect` | Begin OAuth flow |
+| GET | `/auth/social/{provider}/callback` | `security-advanced-auth.social.callback` | OAuth callback |
+| POST | `/auth/social/{provider}/unlink` | `security-advanced-auth.social.unlink` | Unlink (requires `auth`) |
+
+Default middleware: `['web']`. Override:
+
+```php
+'routes' => ['social' => ['middleware' => ['web', 'throttle:social-auth']]],
+```
+
+## SSO (SAML / OIDC / LDAP)
+
+| Method | Path | Name |
+|---|---|---|
+| GET | `/auth/sso/{slug}/login` | `security-advanced-auth.sso.login` |
+| GET / POST | `/auth/sso/{slug}/callback` | `security-advanced-auth.sso.callback` |
+| POST | `/auth/sso/{slug}/logout` | `security-advanced-auth.sso.logout` |
+| GET | `/auth/sso/{slug}/logout/callback` | `security-advanced-auth.sso.logout.callback` |
+| GET | `/auth/sso/{slug}/metadata` | `security-advanced-auth.sso.metadata` |
+
+GET + POST on `callback` covers OIDC (GET, auth code flow) and SAML (POST, ACS).
+
+> **CSRF note**: SAML ACS endpoints are POST-from-IdP — your CSRF middleware will reject them unless excluded. Add the path to `VerifyCsrfToken::$except` or use a route group that opts out of CSRF.
+
+## WebAuthn
+
+| Method | Path | Name |
+|---|---|---|
+| POST | `/auth/webauthn/register/options` | `security-advanced-auth.webauthn.register.options` |
+| POST | `/auth/webauthn/register/verify` | `security-advanced-auth.webauthn.register.verify` |
+| POST | `/auth/webauthn/authenticate/options` | `security-advanced-auth.webauthn.authenticate.options` |
+| POST | `/auth/webauthn/authenticate/verify` | `security-advanced-auth.webauthn.authenticate.verify` |
+
+Default middleware: `['api']`. These are JSON endpoints called by the host app's JS, not full pages.
+
+## Customizing the prefix
+
+```php
+'routes' => ['prefix' => 'security'],
+```
+
+Changes the base prefix from `auth` to `security`. So URLs become `/security/social/google/redirect` etc.
+
+## Disabling routes wholesale
+
+```php
+'routes' => ['enabled' => false],
+```
+
+The whole file stops loading. You can then wire your own controllers — call the managers directly:
+
+```php
+Route::get('/my-custom-google-redirect', function () {
+    $url = app(SocialAuthManager::class)->redirect('google');
+    return redirect()->away($url);
+});
+```
+
+## Generating URLs
+
+Always use named routes for callback URIs you register with the IdP / OAuth provider:
+
+```php
+$callbackUrl = route('security-advanced-auth.social.callback', ['provider' => 'google']);
+$ssoMetadataUrl = route('security-advanced-auth.sso.metadata', ['slug' => 'corp-saml']);
+```
+
+Don't hard-code paths — the prefix is configurable and may differ per environment.

--- a/docs/usage/social.md
+++ b/docs/usage/social.md
@@ -1,0 +1,98 @@
+---
+title: Social Authentication
+---
+
+# Social Authentication
+
+`SocialAuthManager` (363 lines) handles OAuth-based social login. 8 providers ship out of the box.
+
+## Endpoints
+
+| Method | Path | Purpose |
+|---|---|---|
+| GET | `/auth/social/{provider}/redirect` | Begin OAuth flow |
+| GET | `/auth/social/{provider}/callback` | OAuth callback |
+| POST | `/auth/social/{provider}/unlink` | Unlink (requires auth) |
+
+## Shipped providers
+
+- `apple` — Sign in with Apple
+- `facebook` — Facebook Login
+- `github` — GitHub
+- `google` — Google
+- `linkedin` — LinkedIn
+- `microsoft` — Microsoft / Azure AD personal
+- `oidc` (`GenericOidcProvider`) — any OIDC provider
+- (Custom — extend `AbstractOAuth2Provider` or `AbstractOidcProvider`)
+
+## Registering a provider
+
+```php
+use ArtisanPackUI\SecurityAdvancedAuth\Authentication\Social\SocialAuthManager;
+
+// In a service provider's boot()
+app( SocialAuthManager::class )->registerProvider( 'google', [
+    'client_id'     => env('GOOGLE_CLIENT_ID'),
+    'client_secret' => env('GOOGLE_CLIENT_SECRET'),
+    'redirect_uri'  => route('security-advanced-auth.social.callback', ['provider' => 'google']),
+    'scopes'        => ['openid', 'email', 'profile'],
+] );
+```
+
+Repeat per provider. Only registered providers respond to the callback routes — unregistered providers throw `RuntimeException`.
+
+## Linking flow
+
+The bundled `SocialAuthController::callback()`:
+
+1. Validates the OAuth `state` parameter (CSRF).
+2. Exchanges the `code` for an access token.
+3. Fetches the user info from the provider.
+4. If `email_domains` is configured and the user's email domain isn't on the list, rejects.
+5. Either:
+   - Logs in an existing user (if a `SocialIdentity` matches the provider's user ID), or
+   - Creates a new user and links a fresh `SocialIdentity`.
+6. Redirects to `config('artisanpack.security-advanced-auth.social.redirect_after_login')`.
+
+## Linking to an existing account
+
+For "connect Google" flows on an existing user's settings page, the `SocialAccountsManager` Livewire component handles the UX. Internally:
+
+```php
+$socialUser = $manager->callback( $provider, $code, $state );
+$manager->linkIdentity( $user, $socialUser, $tokens );
+```
+
+## Unlinking
+
+The Livewire component handles unlinking, or call directly:
+
+```php
+$manager->unlinkIdentity( $user, $provider );
+```
+
+Refuses to unlink the user's only authentication method — they'd be locked out.
+
+## Email domain restriction
+
+To restrict social login to users from specific domains (e.g. only `@mycompany.com`):
+
+```php
+'social' => [
+    'allowed_email_domains' => ['mycompany.com', 'subsidiary.com'],
+],
+```
+
+`null` (default) allows any domain.
+
+## Token refresh
+
+```php
+$manager->refreshTokens( $socialIdentity );
+```
+
+For providers that issue refresh tokens (Google, Microsoft, Facebook), this refreshes the access token using the stored refresh token.
+
+## Custom providers
+
+Implement `SocialProviderInterface` (or extend `AbstractOAuth2Provider` / `AbstractOidcProvider`) and register your class — see [Custom social providers](../advanced/custom-social-providers.md).

--- a/docs/usage/sso.md
+++ b/docs/usage/sso.md
@@ -1,0 +1,110 @@
+---
+title: SSO
+---
+
+# SSO (SAML / OIDC / LDAP)
+
+`SsoManager` (302 lines) orchestrates SAML 2.0, OIDC, and LDAP IdPs. Each IdP is defined as an `SsoConfiguration` row — DB-driven so admins can add new IdPs at runtime.
+
+## Endpoints
+
+| Method | Path | Purpose |
+|---|---|---|
+| GET | `/auth/sso/{slug}/login` | Begin login — redirect to IdP |
+| GET / POST | `/auth/sso/{slug}/callback` | Receive IdP response (SAML ACS = POST, OIDC code = GET) |
+| POST | `/auth/sso/{slug}/logout` | Begin SLO (Single Logout) |
+| GET | `/auth/sso/{slug}/logout/callback` | Receive IdP's SLO callback |
+| GET | `/auth/sso/{slug}/metadata` | SAML SP metadata (XML) |
+
+## Defining an IdP
+
+```php
+use ArtisanPackUI\SecurityAdvancedAuth\Models\SsoConfiguration;
+
+// OIDC
+SsoConfiguration::create([
+    'slug'       => 'corp-okta',
+    'name'       => 'Corporate Okta',
+    'type'       => 'oidc',
+    'config'     => [
+        'discovery_url' => 'https://corp.okta.com/.well-known/openid-configuration',
+        'client_id'     => env('OKTA_CLIENT_ID'),
+        'client_secret' => env('OKTA_CLIENT_SECRET'),
+        'scopes'        => ['openid', 'email', 'profile'],
+    ],
+    'is_enabled' => true,
+    'is_default' => false,
+]);
+
+// SAML
+SsoConfiguration::create([
+    'slug'   => 'corp-saml',
+    'name'   => 'Corporate SAML',
+    'type'   => 'saml',
+    'config' => [
+        'idp_entity_id'   => 'https://saml.corp.example.com',
+        'idp_sso_url'     => 'https://saml.corp.example.com/sso',
+        'idp_certificate' => '-----BEGIN CERTIFICATE-----...',
+    ],
+    'is_enabled' => true,
+]);
+
+// LDAP
+SsoConfiguration::create([
+    'slug'   => 'corp-ldap',
+    'name'   => 'Corporate LDAP',
+    'type'   => 'ldap',
+    'config' => [
+        'host' => 'ldap.corp.example.com',
+        'port' => 636,
+        'base_dn' => 'dc=corp,dc=example,dc=com',
+    ],
+    'is_enabled' => true,
+]);
+```
+
+## Triggering login
+
+```blade
+<a href="{{ route('security-advanced-auth.sso.login', ['slug' => 'corp-okta']) }}">
+    Sign in with Corporate Okta
+</a>
+```
+
+The user goes to the IdP, authenticates there, IdP redirects back to `/auth/sso/corp-okta/callback`. The bundled `SsoController` handles user creation / linking and logs the user in.
+
+## Identity linking
+
+When a user signs in via SSO, the `SsoManager::findOrCreateUser()` method:
+
+1. Looks up an `SsoIdentity` matching the IdP's user identifier
+2. If found, returns the linked User
+3. If not found, creates a new User from the IdP attributes and writes the link
+
+For "link existing account" flows where the user is already signed in, call `linkIdentity( $user, $ssoUser )` directly.
+
+## SAML SP metadata
+
+Your SAML IdP needs your SP metadata to federate. Expose it via the bundled metadata endpoint — `https://your-app.com/auth/sso/{slug}/metadata` returns the XML. Most IdPs (Okta, OneLogin, Azure AD, etc.) accept a URL for SP setup; point them here.
+
+## Single Logout (SLO)
+
+The shipped flow:
+
+1. User clicks "Sign out" in your app.
+2. Your logout flow calls `/auth/sso/{slug}/logout`.
+3. `SsoController` logs the user out locally and redirects to the IdP's logout URL.
+4. After IdP signs the user out, IdP redirects back to `/auth/sso/{slug}/logout/callback`.
+5. `SsoController::logoutCallback()` runs your post-logout logic.
+
+Not all SAML IdPs support SLO. For those that don't, calling local logout is sufficient.
+
+## Required SSO libraries
+
+The shipped `SsoManager` is configuration-driven. The actual SAML / OIDC / LDAP protocol handling needs a library — install whichever fits your stack:
+
+- SAML: `simplesamlphp/saml2` or `onelogin/php-saml`
+- OIDC: `web-token/jwt-framework` or the OIDC client of your choice
+- LDAP: `directorytree/ldaprecord-laravel`
+
+Bind your library's client to the corresponding `SsoProviderInterface` slot — see [Custom SSO providers](../advanced/custom-sso-providers.md).

--- a/docs/usage/suspicious-activity.md
+++ b/docs/usage/suspicious-activity.md
@@ -1,0 +1,75 @@
+---
+title: Suspicious Activity Detection
+---
+
+# Suspicious Activity Detection
+
+`SuspiciousActivityService` (bound to `SuspiciousActivityDetectorInterface`) catches auth-flow patterns that suggest takeover attempts. Distinct from `artisanpack-ui/security-analytics` — this package is auth-specific (impossible travel during login, proxy / Tor detection at sign-in time, etc.).
+
+## Shipped patterns
+
+11 types defined on `SuspiciousActivity`:
+
+| Constant | What it catches |
+|---|---|
+| `TYPE_BRUTE_FORCE` | Many failed login attempts on a single account |
+| `TYPE_IMPOSSIBLE_TRAVEL` | Two logins from geographically distant IPs in too short a time |
+| `TYPE_ANOMALOUS_LOGIN` | Login deviating from user's baseline (time, location, device) |
+| `TYPE_PROXY_DETECTED` | Login from a known proxy IP |
+| `TYPE_TOR_DETECTED` | Login from a Tor exit node |
+| `TYPE_DATACENTER_IP` | Login from a datacenter IP range (suspicious for a regular user) |
+| `TYPE_MULTIPLE_FAILURES` | Sustained failure rate above threshold |
+| `TYPE_DEVICE_CHANGE` | Login from a never-before-seen device |
+| `TYPE_UNUSUAL_TIME` | Login at a time outside user's typical window |
+| `TYPE_SESSION_HIJACKING` | Session token used from a different IP / UA mid-session |
+| `TYPE_CREDENTIAL_STUFFING` | Same password tried across many accounts from one source |
+
+## Detecting
+
+```php
+use ArtisanPackUI\SecurityAdvancedAuth\Authentication\Contracts\SuspiciousActivityDetectorInterface;
+
+$detector = app( SuspiciousActivityDetectorInterface::class );
+
+// At login
+$activity = $detector->analyzeLogin( $user, $request );
+
+if ( $activity && $activity->severity === 'critical' ) {
+    // Refuse login, lock account, etc.
+}
+```
+
+The service writes a `SuspiciousActivity` row per detection. The bundled `SuspiciousActivityList` Livewire component renders them.
+
+## Severity bands
+
+- `SEVERITY_LOW` — gray. Worth tracking, not actionable on its own.
+- `SEVERITY_MEDIUM` — yellow. Show the user, log to audit, maybe send notification.
+- `SEVERITY_HIGH` — orange. Step-up auth required, alert security team.
+- `SEVERITY_CRITICAL` — red. Auto-lock the account, force password reset, page on-call.
+
+Configure auto-action thresholds:
+
+```php
+'suspicious_activity' => [
+    'auto_lock_threshold' => 'high',   // auto-lock for severity >= this
+],
+```
+
+## Recommended actions
+
+`SuspiciousActivity` exposes `ACTION_*` constants for canonical response actions:
+
+- `ACTION_NONE` — log only
+- `ACTION_CAPTCHA` — challenge with CAPTCHA on next attempt
+- `ACTION_STEP_UP` — require step-up auth
+- `ACTION_BLOCK` — refuse the operation
+- `ACTION_LOCKOUT` — lock the account
+
+The service picks an action based on severity + type; the calling code can override.
+
+## Integration with security-analytics
+
+If `artisanpack-ui/security-analytics` is installed, its `SuspiciousActivityService` covers a broader scope (any activity, not just auth flows). This package's service writes to a separate `suspicious_activities` table — both packages can coexist; the analytics one is the broader audit surface, this one is the auth-specific path.
+
+Migration table-name conflict between the two packages is tracked as a separate bug — for now, install only one, or skip the duplicate migration.

--- a/docs/usage/webauthn.md
+++ b/docs/usage/webauthn.md
@@ -1,0 +1,71 @@
+---
+title: WebAuthn / FIDO2
+---
+
+# WebAuthn / FIDO2
+
+`WebAuthnManager` (577 lines) handles registration + authentication ceremonies for passkeys, security keys, and platform authenticators. The package ships interface-level — the actual WebAuthn library is the consumer's choice. Wire a concrete implementation in your service provider.
+
+## Endpoints
+
+| Method | Path | Controller method |
+|---|---|---|
+| POST | `/auth/webauthn/register/options` | `WebAuthnController::registerOptions` |
+| POST | `/auth/webauthn/register/verify` | `WebAuthnController::registerVerify` |
+| POST | `/auth/webauthn/authenticate/options` | `WebAuthnController::authenticateOptions` |
+| POST | `/auth/webauthn/authenticate/verify` | `WebAuthnController::authenticateVerify` |
+
+Prefix and middleware configurable in `config('artisanpack.security-advanced-auth.routes.webauthn')`.
+
+## Registration flow
+
+1. User triggers "Add passkey" in the UI (`WebAuthnCredentialsManager` Livewire component).
+2. Component dispatches `start-webauthn-registration`.
+3. Host JS fetches options: `POST /auth/webauthn/register/options`.
+4. Host JS calls `navigator.credentials.create({publicKey: options})`.
+5. Browser shows the authenticator prompt; user authenticates.
+6. Host JS POSTs the response to `/auth/webauthn/register/verify`.
+7. Server stores the credential as a `WebAuthnCredential` row.
+
+## Authentication flow
+
+1. Login form presents "Sign in with passkey" alongside password.
+2. Host JS fetches: `POST /auth/webauthn/authenticate/options`. Pass `user_id` or omit for discovery flows.
+3. Host JS calls `navigator.credentials.get({publicKey: options})`.
+4. Host JS POSTs the response to `/auth/webauthn/authenticate/verify`.
+5. Server verifies, returns user info, logs the user in.
+
+## Programmatic API
+
+```php
+use ArtisanPackUI\SecurityAdvancedAuth\Authentication\WebAuthn\WebAuthnManager;
+
+$manager = app( WebAuthnManager::class );
+
+// Registration
+$options = $manager->generateRegistrationOptions( $user, [/* options */] );
+$result  = $manager->verifyRegistration( $user, $response, $challenge );
+
+// Authentication
+$options = $manager->generateAuthenticationOptions( $user );
+$result  = $manager->verifyAuthentication( $response, $challenge );
+
+// Credential management
+$creds = $manager->getCredentials( $user );    // Collection<WebAuthnCredential>
+$manager->deleteCredential( $user, $credentialId );
+$manager->updateCredential( $user, $credentialId, ['name' => 'New name'] );
+```
+
+## Passwordless / discovery
+
+`generateAuthenticationOptions(null)` produces options without a specific user — the browser surfaces all stored passkeys and the user picks. Useful for "sign in with passkey" buttons that don't ask for username first.
+
+## Relying Party
+
+The Relying Party ID is your app's domain (e.g. `app.example.com`). Configure in `config('artisanpack.security-advanced-auth.webauthn.relying_party')` — defaults derive from `APP_URL`.
+
+The RP ID is locked at registration time. Changing it later invalidates all existing credentials. Be deliberate about this in production.
+
+## Live tests / e2e
+
+For server-side flow tests, mock the underlying WebAuthn library. For browser-driven tests, [virtual authenticators](https://chromedevtools.github.io/devtools-protocol/tot/WebAuthn/) let Playwright / Cypress simulate the authenticator without needing physical hardware.

--- a/resources/views/livewire/biometric-manager.blade.php
+++ b/resources/views/livewire/biometric-manager.blade.php
@@ -1,0 +1,93 @@
+{{--
+    Biometric credentials manager.
+
+    Plain HTML + Tailwind. The package doesn't depend on
+    artisanpack-ui/livewire-ui-components. The actual biometric prompt
+    is host-app JS — the host listens for the `start-biometric-enrollment`
+    Livewire event, invokes WebAuthn / platform biometrics, and dispatches
+    back to `completeEnrollment` with the response.
+--}}
+<div class="space-y-4">
+    <div class="flex justify-between items-center">
+        <h2 class="text-xl font-bold">{{ __( 'Biometric authentication' ) }}</h2>
+        <button
+            type="button"
+            wire:click="openEnrollModal"
+            @disabled(! $platformSupported)
+            class="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium rounded-md disabled:bg-gray-400 disabled:cursor-not-allowed"
+        >
+            {{ __( 'Add biometric' ) }}
+        </button>
+    </div>
+
+    @if ( ! $platformSupported )
+        <div role="alert" class="bg-yellow-50 border-l-4 border-yellow-500 p-3 rounded text-sm">
+            {{ __( 'Your device does not support biometric authentication.' ) }}
+        </div>
+    @endif
+
+    @if ( empty( $biometrics ) )
+        <p class="text-sm text-gray-500 py-4">{{ __( 'No biometric authenticators registered yet.' ) }}</p>
+    @else
+        <ul class="divide-y border rounded-lg">
+            @foreach ( $biometrics as $biometric )
+                @php $deleting = ( $biometric['id'] ?? null ) === $deletingBiometricId; @endphp
+                <li wire:key="biometric-{{ $biometric['id'] }}" class="flex justify-between items-center px-4 py-3">
+                    <div>
+                        <p class="font-medium">{{ $biometric['name'] ?? __( 'Biometric' ) }}</p>
+                        <p class="text-xs text-gray-500">
+                            {{ __( 'Added' ) }}: {{ $biometric['created_at'] ?? __( 'Unknown' ) }}
+                            @if ( isset( $biometric['last_used_at'] ) )
+                                · {{ __( 'Last used' ) }}: {{ $biometric['last_used_at'] }}
+                            @endif
+                        </p>
+                    </div>
+                    <div>
+                        @if ( $deleting )
+                            <div class="flex gap-2">
+                                <button type="button" wire:click="deleteBiometric('{{ $biometric['id'] }}')" class="text-xs px-3 py-1.5 bg-red-600 hover:bg-red-700 text-white rounded font-medium">
+                                    {{ __( 'Confirm delete' ) }}
+                                </button>
+                                <button type="button" wire:click="cancelDelete" class="text-xs px-3 py-1.5 bg-white hover:bg-gray-50 text-gray-700 border border-gray-300 rounded font-medium">
+                                    {{ __( 'Cancel' ) }}
+                                </button>
+                            </div>
+                        @else
+                            <button type="button" wire:click="confirmDelete('{{ $biometric['id'] }}')" class="text-sm text-red-600 hover:text-red-800 font-medium">
+                                {{ __( 'Delete' ) }}
+                            </button>
+                        @endif
+                    </div>
+                </li>
+            @endforeach
+        </ul>
+    @endif
+
+    {{-- Enrollment modal --}}
+    @if ( $showEnrollModal )
+        <div role="dialog" aria-modal="true" aria-labelledby="biometric-enroll-title" class="fixed inset-0 z-50 overflow-y-auto">
+            <div class="fixed inset-0 bg-black bg-opacity-50" aria-hidden="true"></div>
+            <div class="flex min-h-full items-center justify-center p-4">
+                <div class="relative bg-white rounded-lg shadow-xl max-w-md w-full p-6">
+                    <div class="flex justify-between items-start mb-4">
+                        <h3 id="biometric-enroll-title" class="text-lg font-bold">{{ __( 'Add biometric authenticator' ) }}</h3>
+                        <button type="button" wire:click="closeEnrollModal" class="text-gray-400 hover:text-gray-600" aria-label="{{ __( 'Close' ) }}">&times;</button>
+                    </div>
+                    <form wire:submit.prevent="startEnrollment">
+                        <label for="biometric-name" class="block text-sm font-medium text-gray-700 mb-1">
+                            {{ __( 'Name this authenticator' ) }}
+                        </label>
+                        <input id="biometric-name" type="text" wire:model="newBiometricName" placeholder="{{ __( 'e.g. MacBook Touch ID' ) }}" class="block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm" autofocus />
+                        <div class="mt-4 flex justify-end gap-2">
+                            <button type="button" wire:click="closeEnrollModal" class="px-4 py-2 bg-white hover:bg-gray-50 text-gray-700 border border-gray-300 text-sm font-medium rounded-md">{{ __( 'Cancel' ) }}</button>
+                            <button type="submit" class="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium rounded-md">{{ __( 'Continue' ) }}</button>
+                        </div>
+                    </form>
+                    @if ( $enrollmentOptions )
+                        <p class="mt-4 text-xs text-gray-500">{{ __( 'Awaiting authenticator response…' ) }}</p>
+                    @endif
+                </div>
+            </div>
+        </div>
+    @endif
+</div>

--- a/resources/views/livewire/biometric-manager.blade.php
+++ b/resources/views/livewire/biometric-manager.blade.php
@@ -45,7 +45,7 @@
                     <div>
                         @if ( $deleting )
                             <div class="flex gap-2">
-                                <button type="button" wire:click="deleteBiometric('{{ $biometric['id'] }}')" class="text-xs px-3 py-1.5 bg-red-600 hover:bg-red-700 text-white rounded font-medium">
+                                <button type="button" wire:click="deleteBiometric({{ json_encode($biometric['id']) }})" class="text-xs px-3 py-1.5 bg-red-600 hover:bg-red-700 text-white rounded font-medium">
                                     {{ __( 'Confirm delete' ) }}
                                 </button>
                                 <button type="button" wire:click="cancelDelete" class="text-xs px-3 py-1.5 bg-white hover:bg-gray-50 text-gray-700 border border-gray-300 rounded font-medium">
@@ -53,7 +53,7 @@
                                 </button>
                             </div>
                         @else
-                            <button type="button" wire:click="confirmDelete('{{ $biometric['id'] }}')" class="text-sm text-red-600 hover:text-red-800 font-medium">
+                            <button type="button" wire:click="confirmDelete({{ json_encode($biometric['id']) }})" class="text-sm text-red-600 hover:text-red-800 font-medium">
                                 {{ __( 'Delete' ) }}
                             </button>
                         @endif

--- a/resources/views/livewire/device-manager.blade.php
+++ b/resources/views/livewire/device-manager.blade.php
@@ -56,18 +56,18 @@
 
                         <div class="flex flex-col gap-2 items-end">
                             @if ( ! ( $device['trusted'] ?? false ) )
-                                <button type="button" wire:click="trustDevice('{{ $device['id'] }}')" class="text-sm text-blue-600 hover:text-blue-800 font-medium">
+                                <button type="button" wire:click="trustDevice({{ json_encode($device['id']) }})" class="text-sm text-blue-600 hover:text-blue-800 font-medium">
                                     {{ __( 'Trust this device' ) }}
                                 </button>
                             @endif
                             @if ( ! $isCurrent )
                                 @if ( $isRevoking )
                                     <div class="flex gap-2">
-                                        <button type="button" wire:click="revokeDevice('{{ $device['id'] }}')" class="text-xs px-3 py-1.5 bg-red-600 hover:bg-red-700 text-white rounded font-medium">{{ __( 'Confirm revoke' ) }}</button>
+                                        <button type="button" wire:click="revokeDevice({{ json_encode($device['id']) }})" class="text-xs px-3 py-1.5 bg-red-600 hover:bg-red-700 text-white rounded font-medium">{{ __( 'Confirm revoke' ) }}</button>
                                         <button type="button" wire:click="cancelRevoke" class="text-xs px-3 py-1.5 bg-white hover:bg-gray-50 text-gray-700 border border-gray-300 rounded font-medium">{{ __( 'Cancel' ) }}</button>
                                     </div>
                                 @else
-                                    <button type="button" wire:click="confirmRevoke('{{ $device['id'] }}')" class="text-sm text-red-600 hover:text-red-800 font-medium">{{ __( 'Revoke' ) }}</button>
+                                    <button type="button" wire:click="confirmRevoke({{ json_encode($device['id']) }})" class="text-sm text-red-600 hover:text-red-800 font-medium">{{ __( 'Revoke' ) }}</button>
                                 @endif
                             @endif
                         </div>

--- a/resources/views/livewire/device-manager.blade.php
+++ b/resources/views/livewire/device-manager.blade.php
@@ -1,0 +1,79 @@
+{{--
+    Device manager — lists known devices and offers trust / revoke controls.
+    Plain HTML + Tailwind, no livewire-ui-components dependency.
+--}}
+<div class="space-y-4">
+    <div class="flex justify-between items-center">
+        <h2 class="text-xl font-bold">{{ __( 'Trusted devices' ) }}</h2>
+        @if ( count( $devices ) > 1 )
+            <button
+                type="button"
+                wire:click="revokeAllOtherDevices"
+                wire:confirm="{{ __( 'Revoke all other devices?' ) }}"
+                class="text-sm text-red-600 hover:text-red-800 font-medium"
+            >
+                {{ __( 'Revoke all other devices' ) }}
+            </button>
+        @endif
+    </div>
+
+    @if ( empty( $devices ) )
+        <p class="text-sm text-gray-500 py-4">{{ __( 'No known devices yet.' ) }}</p>
+    @else
+        <div class="space-y-2">
+            @foreach ( $devices as $device )
+                @php
+                    $isCurrent = ( $device['id'] ?? null ) === $currentDeviceId;
+                    $isRevoking = ( $device['id'] ?? null ) === $revokingDeviceId;
+                @endphp
+                <div wire:key="device-{{ $device['id'] }}" class="border rounded-lg p-4 {{ $isCurrent ? 'bg-blue-50 border-blue-200' : 'bg-white border-gray-200' }}">
+                    <div class="flex items-start justify-between gap-4">
+                        <div class="flex-1 space-y-1">
+                            <div class="flex items-center gap-2">
+                                <span class="font-medium">{{ $device['name'] ?? $device['device'] ?? __( 'Unknown device' ) }}</span>
+                                @if ( $isCurrent )
+                                    <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-800">{{ __( 'This device' ) }}</span>
+                                @endif
+                                @if ( $device['trusted'] ?? false )
+                                    <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-green-100 text-green-800">{{ __( 'Trusted' ) }}</span>
+                                @endif
+                            </div>
+                            <div class="text-sm text-gray-600 space-y-0.5">
+                                @if ( isset( $device['browser'] ) )
+                                    <div>{{ __( 'Browser' ) }}: {{ $device['browser'] }}</div>
+                                @endif
+                                @if ( isset( $device['os'] ) )
+                                    <div>{{ __( 'OS' ) }}: {{ $device['os'] }}</div>
+                                @endif
+                                @if ( isset( $device['ip_address'] ) )
+                                    <div>{{ __( 'IP' ) }}: <span class="font-mono">{{ $device['ip_address'] }}</span></div>
+                                @endif
+                                @if ( isset( $device['last_seen_at'] ) )
+                                    <div>{{ __( 'Last seen' ) }}: {{ $device['last_seen_at'] }}</div>
+                                @endif
+                            </div>
+                        </div>
+
+                        <div class="flex flex-col gap-2 items-end">
+                            @if ( ! ( $device['trusted'] ?? false ) )
+                                <button type="button" wire:click="trustDevice('{{ $device['id'] }}')" class="text-sm text-blue-600 hover:text-blue-800 font-medium">
+                                    {{ __( 'Trust this device' ) }}
+                                </button>
+                            @endif
+                            @if ( ! $isCurrent )
+                                @if ( $isRevoking )
+                                    <div class="flex gap-2">
+                                        <button type="button" wire:click="revokeDevice('{{ $device['id'] }}')" class="text-xs px-3 py-1.5 bg-red-600 hover:bg-red-700 text-white rounded font-medium">{{ __( 'Confirm revoke' ) }}</button>
+                                        <button type="button" wire:click="cancelRevoke" class="text-xs px-3 py-1.5 bg-white hover:bg-gray-50 text-gray-700 border border-gray-300 rounded font-medium">{{ __( 'Cancel' ) }}</button>
+                                    </div>
+                                @else
+                                    <button type="button" wire:click="confirmRevoke('{{ $device['id'] }}')" class="text-sm text-red-600 hover:text-red-800 font-medium">{{ __( 'Revoke' ) }}</button>
+                                @endif
+                            @endif
+                        </div>
+                    </div>
+                </div>
+            @endforeach
+        </div>
+    @endif
+</div>

--- a/resources/views/livewire/social-accounts-manager.blade.php
+++ b/resources/views/livewire/social-accounts-manager.blade.php
@@ -31,11 +31,11 @@
                     <div>
                         @if ( $unlinking )
                             <div class="flex gap-2">
-                                <button type="button" wire:click="unlink('{{ $account['provider'] }}')" class="text-xs px-3 py-1.5 bg-red-600 hover:bg-red-700 text-white rounded font-medium">{{ __( 'Confirm unlink' ) }}</button>
+                                <button type="button" wire:click="unlink({{ json_encode($account['provider']) }})" class="text-xs px-3 py-1.5 bg-red-600 hover:bg-red-700 text-white rounded font-medium">{{ __( 'Confirm unlink' ) }}</button>
                                 <button type="button" wire:click="cancelUnlink" class="text-xs px-3 py-1.5 bg-white hover:bg-gray-50 text-gray-700 border border-gray-300 rounded font-medium">{{ __( 'Cancel' ) }}</button>
                             </div>
                         @else
-                            <button type="button" wire:click="confirmUnlink('{{ $account['provider'] }}')" class="text-sm text-red-600 hover:text-red-800 font-medium">{{ __( 'Unlink' ) }}</button>
+                            <button type="button" wire:click="confirmUnlink({{ json_encode($account['provider']) }})" class="text-sm text-red-600 hover:text-red-800 font-medium">{{ __( 'Unlink' ) }}</button>
                         @endif
                     </div>
                 </li>
@@ -51,7 +51,7 @@
                 @foreach ( $availableProviders as $provider )
                     <button
                         type="button"
-                        wire:click="link('{{ $provider }}')"
+                        wire:click="link({{ json_encode($provider) }})"
                         class="inline-flex items-center px-4 py-2 bg-white hover:bg-gray-50 text-gray-700 border border-gray-300 text-sm font-medium rounded-md capitalize"
                     >
                         {{ __( 'Link' ) }} {{ $provider }}

--- a/resources/views/livewire/social-accounts-manager.blade.php
+++ b/resources/views/livewire/social-accounts-manager.blade.php
@@ -1,0 +1,63 @@
+{{--
+    Social accounts manager — list of linked OAuth providers and link/unlink controls.
+    Plain HTML + Tailwind, no livewire-ui-components dependency.
+--}}
+<div class="space-y-4">
+    <div>
+        <h2 class="text-xl font-bold">{{ __( 'Connected accounts' ) }}</h2>
+        <p class="text-sm text-gray-600 mt-1">{{ __( 'Link external providers so you can sign in with them.' ) }}</p>
+    </div>
+
+    @if ( empty( $linkedAccounts ) )
+        <p class="text-sm text-gray-500 py-2">{{ __( 'No connected accounts yet.' ) }}</p>
+    @else
+        <ul class="divide-y border rounded-lg">
+            @foreach ( $linkedAccounts as $account )
+                @php $unlinking = ( $account['provider'] ?? null ) === $unlinkingProvider; @endphp
+                <li wire:key="linked-{{ $account['provider'] }}" class="flex justify-between items-center px-4 py-3">
+                    <div>
+                        <p class="font-medium capitalize">{{ $account['provider'] ?? __( 'Unknown' ) }}</p>
+                        <p class="text-xs text-gray-500">
+                            @if ( isset( $account['provider_user_email'] ) )
+                                {{ $account['provider_user_email'] }}
+                            @elseif ( isset( $account['provider_user_id'] ) )
+                                ID: {{ $account['provider_user_id'] }}
+                            @endif
+                            @if ( isset( $account['linked_at'] ) )
+                                · {{ __( 'Linked' ) }}: {{ $account['linked_at'] }}
+                            @endif
+                        </p>
+                    </div>
+                    <div>
+                        @if ( $unlinking )
+                            <div class="flex gap-2">
+                                <button type="button" wire:click="unlink('{{ $account['provider'] }}')" class="text-xs px-3 py-1.5 bg-red-600 hover:bg-red-700 text-white rounded font-medium">{{ __( 'Confirm unlink' ) }}</button>
+                                <button type="button" wire:click="cancelUnlink" class="text-xs px-3 py-1.5 bg-white hover:bg-gray-50 text-gray-700 border border-gray-300 rounded font-medium">{{ __( 'Cancel' ) }}</button>
+                            </div>
+                        @else
+                            <button type="button" wire:click="confirmUnlink('{{ $account['provider'] }}')" class="text-sm text-red-600 hover:text-red-800 font-medium">{{ __( 'Unlink' ) }}</button>
+                        @endif
+                    </div>
+                </li>
+            @endforeach
+        </ul>
+    @endif
+
+    {{-- Available providers to link --}}
+    @if ( ! empty( $availableProviders ) )
+        <div>
+            <h3 class="text-base font-semibold mb-2">{{ __( 'Available providers' ) }}</h3>
+            <div class="flex flex-wrap gap-2">
+                @foreach ( $availableProviders as $provider )
+                    <button
+                        type="button"
+                        wire:click="link('{{ $provider }}')"
+                        class="inline-flex items-center px-4 py-2 bg-white hover:bg-gray-50 text-gray-700 border border-gray-300 text-sm font-medium rounded-md capitalize"
+                    >
+                        {{ __( 'Link' ) }} {{ $provider }}
+                    </button>
+                @endforeach
+            </div>
+        </div>
+    @endif
+</div>

--- a/resources/views/livewire/suspicious-activity-list.blade.php
+++ b/resources/views/livewire/suspicious-activity-list.blade.php
@@ -1,0 +1,82 @@
+{{--
+    Suspicious activity list (advanced auth surface — auth-flow specific
+    suspicious activity such as impossible travel, proxy detection, etc.).
+
+    Plain HTML + Tailwind by design.
+--}}
+<div>
+    <div class="flex justify-between items-center mb-6">
+        <h1 class="text-2xl font-bold">{{ __( 'Suspicious activity' ) }}</h1>
+    </div>
+
+    {{-- Filters --}}
+    <div class="bg-white shadow rounded-lg p-4 mb-6">
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>
+                <label for="filter-severity" class="block text-sm font-medium text-gray-700 mb-1">{{ __( 'Severity' ) }}</label>
+                <select id="filter-severity" wire:model.live="filterSeverity" class="block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm">
+                    @foreach ( $this->severityOptions as $value => $label )
+                        <option value="{{ $value }}">{{ $label }}</option>
+                    @endforeach
+                </select>
+            </div>
+            <div>
+                <label for="filter-type" class="block text-sm font-medium text-gray-700 mb-1">{{ __( 'Type' ) }}</label>
+                <select id="filter-type" wire:model.live="filterType" class="block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm">
+                    @foreach ( $this->typeOptions as $value => $label )
+                        <option value="{{ $value }}">{{ $label }}</option>
+                    @endforeach
+                </select>
+            </div>
+        </div>
+    </div>
+
+    {{-- Table --}}
+    <div class="bg-white shadow rounded-lg p-4">
+        @if ( $activities->isEmpty() )
+            <div class="text-center py-12 text-gray-500">
+                <p class="text-lg font-medium">{{ __( 'No suspicious activity found.' ) }}</p>
+            </div>
+        @else
+            <div class="overflow-x-auto">
+                <table class="w-full">
+                    <thead>
+                        <tr class="border-b">
+                            <th class="text-left px-4 py-3 font-semibold text-sm text-gray-700">{{ __( 'When' ) }}</th>
+                            <th class="text-left px-4 py-3 font-semibold text-sm text-gray-700">{{ __( 'Type' ) }}</th>
+                            <th class="text-left px-4 py-3 font-semibold text-sm text-gray-700">{{ __( 'Severity' ) }}</th>
+                            <th class="text-left px-4 py-3 font-semibold text-sm text-gray-700">{{ __( 'IP' ) }}</th>
+                            <th class="text-left px-4 py-3 font-semibold text-sm text-gray-700">{{ __( 'Details' ) }}</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach ( $activities as $activity )
+                            <tr wire:key="adv-suspicious-{{ $activity->id }}" class="border-b hover:bg-gray-50">
+                                <td class="px-4 py-3 text-sm whitespace-nowrap">{{ $activity->created_at?->diffForHumans() }}</td>
+                                <td class="px-4 py-3 text-sm">{{ $this->typeOptions[ $activity->type ] ?? $activity->type }}</td>
+                                <td class="px-4 py-3 text-sm">
+                                    <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium {{ $this->getSeverityClass( $activity->severity ) }}">
+                                        {{ $this->severityOptions[ $activity->severity ] ?? $activity->severity }}
+                                    </span>
+                                </td>
+                                <td class="px-4 py-3 text-sm font-mono">{{ $activity->ip_address ?? __( '—' ) }}</td>
+                                <td class="px-4 py-3 text-sm">
+                                    @if ( $activity->details )
+                                        <details>
+                                            <summary class="cursor-pointer text-blue-600 hover:text-blue-800">{{ __( 'View details' ) }}</summary>
+                                            <pre class="mt-2 p-3 bg-gray-50 rounded text-xs overflow-auto max-w-md">{{ json_encode( $activity->details, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) }}</pre>
+                                        </details>
+                                    @else
+                                        <span class="text-gray-400">{{ __( '—' ) }}</span>
+                                    @endif
+                                </td>
+                            </tr>
+                        @endforeach
+                    </tbody>
+                </table>
+            </div>
+
+            <div class="mt-4">{{ $activities->links() }}</div>
+        @endif
+    </div>
+</div>

--- a/resources/views/livewire/webauthn-credentials-manager.blade.php
+++ b/resources/views/livewire/webauthn-credentials-manager.blade.php
@@ -40,11 +40,11 @@
                     <div>
                         @if ( $deleting )
                             <div class="flex gap-2">
-                                <button type="button" wire:click="deleteCredential('{{ $credential['id'] }}')" class="text-xs px-3 py-1.5 bg-red-600 hover:bg-red-700 text-white rounded font-medium">{{ __( 'Confirm delete' ) }}</button>
+                                <button type="button" wire:click="deleteCredential({{ json_encode($credential['id']) }})" class="text-xs px-3 py-1.5 bg-red-600 hover:bg-red-700 text-white rounded font-medium">{{ __( 'Confirm delete' ) }}</button>
                                 <button type="button" wire:click="cancelDelete" class="text-xs px-3 py-1.5 bg-white hover:bg-gray-50 text-gray-700 border border-gray-300 rounded font-medium">{{ __( 'Cancel' ) }}</button>
                             </div>
                         @else
-                            <button type="button" wire:click="confirmDelete('{{ $credential['id'] }}')" class="text-sm text-red-600 hover:text-red-800 font-medium">{{ __( 'Delete' ) }}</button>
+                            <button type="button" wire:click="confirmDelete({{ json_encode($credential['id']) }})" class="text-sm text-red-600 hover:text-red-800 font-medium">{{ __( 'Delete' ) }}</button>
                         @endif
                     </div>
                 </li>

--- a/resources/views/livewire/webauthn-credentials-manager.blade.php
+++ b/resources/views/livewire/webauthn-credentials-manager.blade.php
@@ -1,0 +1,82 @@
+{{--
+    WebAuthn / passkey credentials manager.
+
+    Plain HTML + Tailwind. Actual WebAuthn ceremony is browser JS — the
+    host app listens for the `start-webauthn-registration` Livewire event,
+    calls navigator.credentials.create(), and dispatches the response back
+    to `completeRegistration`.
+--}}
+<div class="space-y-4">
+    <div class="flex justify-between items-center">
+        <h2 class="text-xl font-bold">{{ __( 'Passkeys & security keys' ) }}</h2>
+        <button
+            type="button"
+            wire:click="openRegisterModal"
+            class="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium rounded-md"
+        >
+            {{ __( 'Add passkey' ) }}
+        </button>
+    </div>
+
+    @if ( empty( $credentials ) )
+        <p class="text-sm text-gray-500 py-4">{{ __( 'No passkeys registered yet.' ) }}</p>
+    @else
+        <ul class="divide-y border rounded-lg">
+            @foreach ( $credentials as $credential )
+                @php $deleting = ( $credential['id'] ?? null ) === $deletingCredentialId; @endphp
+                <li wire:key="webauthn-{{ $credential['id'] }}" class="flex justify-between items-center px-4 py-3">
+                    <div>
+                        <p class="font-medium">{{ $credential['name'] ?? __( 'Unnamed key' ) }}</p>
+                        <p class="text-xs text-gray-500">
+                            @if ( isset( $credential['transports'] ) )
+                                {{ implode( ', ', $credential['transports'] ) }} ·
+                            @endif
+                            {{ __( 'Added' ) }}: {{ $credential['created_at'] ?? __( 'Unknown' ) }}
+                            @if ( isset( $credential['last_used_at'] ) )
+                                · {{ __( 'Last used' ) }}: {{ $credential['last_used_at'] }}
+                            @endif
+                        </p>
+                    </div>
+                    <div>
+                        @if ( $deleting )
+                            <div class="flex gap-2">
+                                <button type="button" wire:click="deleteCredential('{{ $credential['id'] }}')" class="text-xs px-3 py-1.5 bg-red-600 hover:bg-red-700 text-white rounded font-medium">{{ __( 'Confirm delete' ) }}</button>
+                                <button type="button" wire:click="cancelDelete" class="text-xs px-3 py-1.5 bg-white hover:bg-gray-50 text-gray-700 border border-gray-300 rounded font-medium">{{ __( 'Cancel' ) }}</button>
+                            </div>
+                        @else
+                            <button type="button" wire:click="confirmDelete('{{ $credential['id'] }}')" class="text-sm text-red-600 hover:text-red-800 font-medium">{{ __( 'Delete' ) }}</button>
+                        @endif
+                    </div>
+                </li>
+            @endforeach
+        </ul>
+    @endif
+
+    {{-- Registration modal --}}
+    @if ( $showRegisterModal )
+        <div role="dialog" aria-modal="true" aria-labelledby="webauthn-register-title" class="fixed inset-0 z-50 overflow-y-auto">
+            <div class="fixed inset-0 bg-black bg-opacity-50" aria-hidden="true"></div>
+            <div class="flex min-h-full items-center justify-center p-4">
+                <div class="relative bg-white rounded-lg shadow-xl max-w-md w-full p-6">
+                    <div class="flex justify-between items-start mb-4">
+                        <h3 id="webauthn-register-title" class="text-lg font-bold">{{ __( 'Add a passkey' ) }}</h3>
+                        <button type="button" wire:click="closeRegisterModal" class="text-gray-400 hover:text-gray-600" aria-label="{{ __( 'Close' ) }}">&times;</button>
+                    </div>
+                    <form wire:submit.prevent="startRegistration">
+                        <label for="webauthn-name" class="block text-sm font-medium text-gray-700 mb-1">
+                            {{ __( 'Name this passkey' ) }}
+                        </label>
+                        <input id="webauthn-name" type="text" wire:model="newCredentialName" placeholder="{{ __( 'e.g. iPhone Face ID, YubiKey 5' ) }}" class="block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm" autofocus />
+                        <div class="mt-4 flex justify-end gap-2">
+                            <button type="button" wire:click="closeRegisterModal" class="px-4 py-2 bg-white hover:bg-gray-50 text-gray-700 border border-gray-300 text-sm font-medium rounded-md">{{ __( 'Cancel' ) }}</button>
+                            <button type="submit" class="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium rounded-md">{{ __( 'Continue' ) }}</button>
+                        </div>
+                    </form>
+                    @if ( $registrationOptions )
+                        <p class="mt-4 text-xs text-gray-500">{{ __( 'Follow the prompts from your authenticator…' ) }}</p>
+                    @endif
+                </div>
+            </div>
+        </div>
+    @endif
+</div>

--- a/routes/auth.php
+++ b/routes/auth.php
@@ -54,7 +54,15 @@ Route::middleware( $ssoMiddleware )
     } );
 
 // --- WebAuthn / FIDO2 ------------------------------------------------------
-$webauthnMiddleware = config( 'artisanpack.security-advanced-auth.routes.webauthn.middleware', ['api'] );
+//
+// `registerVerify` requires the authenticated user; `authenticateVerify`
+// calls `Auth::login()` which needs an active session to persist. Both are
+// state-changing POSTs, so they need CSRF protection. The default `web`
+// middleware group provides StartSession + VerifyCsrfToken; the bare `api`
+// group typically does not. Host apps overriding this config must include
+// session + CSRF middleware for the verify endpoints (the *_options
+// endpoints are read-only and safe under `api`).
+$webauthnMiddleware = config( 'artisanpack.security-advanced-auth.routes.webauthn.middleware', ['web'] );
 
 Route::middleware( $webauthnMiddleware )
     ->prefix( "{$prefix}/webauthn" )

--- a/routes/auth.php
+++ b/routes/auth.php
@@ -1,0 +1,67 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\SecurityAdvancedAuth\Http\Controllers\SocialAuthController;
+use ArtisanPackUI\SecurityAdvancedAuth\Http\Controllers\SsoController;
+use ArtisanPackUI\SecurityAdvancedAuth\Http\Controllers\WebAuthnController;
+use Illuminate\Support\Facades\Route;
+
+/*
+|--------------------------------------------------------------------------
+| Security Advanced Auth Routes
+|--------------------------------------------------------------------------
+|
+| Social OAuth, SSO (SAML / OIDC / LDAP), and WebAuthn callback routes.
+|
+| The whole file is loaded only when
+| `artisanpack.security-advanced-auth.routes.enabled` is true (default).
+|
+| Each route group respects its own middleware list — the social group
+| typically wants 'web', WebAuthn JSON endpoints typically want 'api'.
+|
+*/
+
+$prefix = config( 'artisanpack.security-advanced-auth.routes.prefix', 'auth' );
+
+// --- Social OAuth ----------------------------------------------------------
+$socialMiddleware = config( 'artisanpack.security-advanced-auth.routes.social.middleware', ['web'] );
+
+Route::middleware( $socialMiddleware )
+    ->prefix( "{$prefix}/social" )
+    ->name( 'security-advanced-auth.social.' )
+    ->group( function (): void {
+        Route::get( '/{provider}/redirect', [SocialAuthController::class, 'redirect'] )->name( 'redirect' );
+        Route::get( '/{provider}/callback', [SocialAuthController::class, 'callback'] )->name( 'callback' );
+        Route::post( '/{provider}/unlink', [SocialAuthController::class, 'unlink'] )
+            ->middleware( 'auth' )
+            ->name( 'unlink' );
+    } );
+
+// --- SSO (SAML / OIDC / LDAP) ----------------------------------------------
+$ssoMiddleware = config( 'artisanpack.security-advanced-auth.routes.sso.middleware', ['web'] );
+
+Route::middleware( $ssoMiddleware )
+    ->prefix( "{$prefix}/sso" )
+    ->name( 'security-advanced-auth.sso.' )
+    ->group( function (): void {
+        Route::get( '/{slug}/login', [SsoController::class, 'login'] )->name( 'login' );
+        // Both GET and POST — OIDC implicit / auth-code flows use GET, SAML ACS uses POST.
+        Route::match( ['GET', 'POST'], '/{slug}/callback', [SsoController::class, 'callback'] )->name( 'callback' );
+        Route::post( '/{slug}/logout', [SsoController::class, 'logout'] )->name( 'logout' );
+        Route::get( '/{slug}/logout/callback', [SsoController::class, 'logoutCallback'] )->name( 'logout.callback' );
+        Route::get( '/{slug}/metadata', [SsoController::class, 'metadata'] )->name( 'metadata' );
+    } );
+
+// --- WebAuthn / FIDO2 ------------------------------------------------------
+$webauthnMiddleware = config( 'artisanpack.security-advanced-auth.routes.webauthn.middleware', ['api'] );
+
+Route::middleware( $webauthnMiddleware )
+    ->prefix( "{$prefix}/webauthn" )
+    ->name( 'security-advanced-auth.webauthn.' )
+    ->group( function (): void {
+        Route::post( '/register/options', [WebAuthnController::class, 'registerOptions'] )->name( 'register.options' );
+        Route::post( '/register/verify', [WebAuthnController::class, 'registerVerify'] )->name( 'register.verify' );
+        Route::post( '/authenticate/options', [WebAuthnController::class, 'authenticateOptions'] )->name( 'authenticate.options' );
+        Route::post( '/authenticate/verify', [WebAuthnController::class, 'authenticateVerify'] )->name( 'authenticate.verify' );
+    } );

--- a/src/Authentication/Biometric/BiometricManager.php
+++ b/src/Authentication/Biometric/BiometricManager.php
@@ -1,5 +1,16 @@
 <?php
 
+/**
+ * BiometricManager biometric class.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SecurityAdvancedAuth
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.0.0
+ */
+
 declare( strict_types=1 );
 
 namespace ArtisanPackUI\SecurityAdvancedAuth\Authentication\Biometric;
@@ -186,7 +197,7 @@ class BiometricManager
 
         // Return first available provider
         foreach ( $this->providers as $name => $provider ) {
-            if ( $provider->isAvailable( $deviceInfo)) {
+            if ( $provider->isAvailable( $deviceInfo ) ) {
                 return $name;
             }
         }

--- a/src/Authentication/Biometric/WebAuthnBiometricProvider.php
+++ b/src/Authentication/Biometric/WebAuthnBiometricProvider.php
@@ -1,5 +1,16 @@
 <?php
 
+/**
+ * WebAuthnBiometricProvider biometric class.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SecurityAdvancedAuth
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.0.0
+ */
+
 declare( strict_types=1 );
 
 namespace ArtisanPackUI\SecurityAdvancedAuth\Authentication\Biometric;

--- a/src/Authentication/Contracts/BiometricProviderInterface.php
+++ b/src/Authentication/Contracts/BiometricProviderInterface.php
@@ -1,5 +1,16 @@
 <?php
 
+/**
+ * BiometricProviderInterface contract.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SecurityAdvancedAuth
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.0.0
+ */
+
 declare( strict_types=1 );
 
 namespace ArtisanPackUI\SecurityAdvancedAuth\Authentication\Contracts;

--- a/src/Authentication/Contracts/DeviceFingerprintInterface.php
+++ b/src/Authentication/Contracts/DeviceFingerprintInterface.php
@@ -1,5 +1,16 @@
 <?php
 
+/**
+ * DeviceFingerprintInterface contract.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SecurityAdvancedAuth
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.0.0
+ */
+
 declare( strict_types=1 );
 
 namespace ArtisanPackUI\SecurityAdvancedAuth\Authentication\Contracts;

--- a/src/Authentication/Contracts/SocialProviderInterface.php
+++ b/src/Authentication/Contracts/SocialProviderInterface.php
@@ -1,5 +1,16 @@
 <?php
 
+/**
+ * SocialProviderInterface contract.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SecurityAdvancedAuth
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.0.0
+ */
+
 declare( strict_types=1 );
 
 namespace ArtisanPackUI\SecurityAdvancedAuth\Authentication\Contracts;

--- a/src/Authentication/Contracts/SsoProviderInterface.php
+++ b/src/Authentication/Contracts/SsoProviderInterface.php
@@ -1,5 +1,16 @@
 <?php
 
+/**
+ * SsoProviderInterface contract.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SecurityAdvancedAuth
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.0.0
+ */
+
 declare( strict_types=1 );
 
 namespace ArtisanPackUI\SecurityAdvancedAuth\Authentication\Contracts;

--- a/src/Authentication/Contracts/SuspiciousActivityDetectorInterface.php
+++ b/src/Authentication/Contracts/SuspiciousActivityDetectorInterface.php
@@ -1,5 +1,16 @@
 <?php
 
+/**
+ * SuspiciousActivityDetectorInterface contract.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SecurityAdvancedAuth
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.0.0
+ */
+
 declare( strict_types=1 );
 
 namespace ArtisanPackUI\SecurityAdvancedAuth\Authentication\Contracts;

--- a/src/Authentication/Contracts/WebAuthnInterface.php
+++ b/src/Authentication/Contracts/WebAuthnInterface.php
@@ -1,5 +1,16 @@
 <?php
 
+/**
+ * WebAuthnInterface contract.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SecurityAdvancedAuth
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.0.0
+ */
+
 declare( strict_types=1 );
 
 namespace ArtisanPackUI\SecurityAdvancedAuth\Authentication\Contracts;
@@ -83,5 +94,5 @@ interface WebAuthnInterface
     /**
      * Invalidate a challenge after use.
      */
-    public function invalidateChallenge( string $challenge): void;
+    public function invalidateChallenge( string $challenge ): void;
 }

--- a/src/Authentication/Detection/SuspiciousActivityService.php
+++ b/src/Authentication/Detection/SuspiciousActivityService.php
@@ -1,5 +1,16 @@
 <?php
 
+/**
+ * SuspiciousActivityService suspicious activity detection service.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SecurityAdvancedAuth
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.0.0
+ */
+
 declare( strict_types=1 );
 
 namespace ArtisanPackUI\SecurityAdvancedAuth\Authentication\Detection;
@@ -605,14 +616,14 @@ class SuspiciousActivityService implements SuspiciousActivityDetectorInterface
         // Try to get timezone from user model
         if ( method_exists( $user, 'getAttribute' ) ) {
             $userTimezone = $user->getAttribute( 'timezone' );
-            if ( $userTimezone && $this->isValidTimezone( $userTimezone)) {
+            if ( $userTimezone && $this->isValidTimezone( $userTimezone ) ) {
                 return $userTimezone;
             }
         }
 
         // Fall back to application timezone if explicitly set
-        $appTimezone = config( 'app.timezone');
-        if ( $appTimezone && 'UTC' !== $appTimezone && $this->isValidTimezone( $appTimezone)) {
+        $appTimezone = config( 'app.timezone' );
+        if ( $appTimezone && 'UTC' !== $appTimezone && $this->isValidTimezone( $appTimezone ) ) {
             return $appTimezone;
         }
 
@@ -623,10 +634,10 @@ class SuspiciousActivityService implements SuspiciousActivityDetectorInterface
     /**
      * Check if a timezone string is valid.
      */
-    protected function isValidTimezone( string $timezone): bool
+    protected function isValidTimezone( string $timezone ): bool
     {
         try {
-            new DateTimeZone( $timezone);
+            new DateTimeZone( $timezone );
 
             return true;
         } catch ( Exception $e) {

--- a/src/Authentication/Detection/SuspiciousActivityService.php
+++ b/src/Authentication/Detection/SuspiciousActivityService.php
@@ -640,7 +640,7 @@ class SuspiciousActivityService implements SuspiciousActivityDetectorInterface
             new DateTimeZone( $timezone );
 
             return true;
-        } catch ( Exception $e) {
+        } catch ( Exception $e ) {
             return false;
         }
     }

--- a/src/Authentication/Device/DeviceFingerprintService.php
+++ b/src/Authentication/Device/DeviceFingerprintService.php
@@ -1,5 +1,16 @@
 <?php
 
+/**
+ * DeviceFingerprintService device fingerprinting service.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SecurityAdvancedAuth
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.0.0
+ */
+
 declare( strict_types=1 );
 
 namespace ArtisanPackUI\SecurityAdvancedAuth\Authentication\Device;
@@ -308,7 +319,7 @@ class DeviceFingerprintService implements DeviceFingerprintInterface
      *
      * @return array<string, mixed>|null
      */
-    protected function getLocationFromRequest( Request $request): ?array
+    protected function getLocationFromRequest( Request $request ): ?array
     {
         // In production, use a GeoIP service
         return [

--- a/src/Authentication/Social/Providers/AbstractOAuth2Provider.php
+++ b/src/Authentication/Social/Providers/AbstractOAuth2Provider.php
@@ -1,5 +1,16 @@
 <?php
 
+/**
+ * AbstractOAuth2Provider social OAuth provider.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SecurityAdvancedAuth
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.0.0
+ */
+
 declare( strict_types=1 );
 
 namespace ArtisanPackUI\SecurityAdvancedAuth\Authentication\Social\Providers;

--- a/src/Authentication/Social/Providers/AbstractOidcProvider.php
+++ b/src/Authentication/Social/Providers/AbstractOidcProvider.php
@@ -1,5 +1,16 @@
 <?php
 
+/**
+ * AbstractOidcProvider social OAuth provider.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SecurityAdvancedAuth
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.0.0
+ */
+
 declare( strict_types=1 );
 
 namespace ArtisanPackUI\SecurityAdvancedAuth\Authentication\Social\Providers;

--- a/src/Authentication/Social/Providers/AppleProvider.php
+++ b/src/Authentication/Social/Providers/AppleProvider.php
@@ -1,5 +1,16 @@
 <?php
 
+/**
+ * AppleProvider social OAuth provider.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SecurityAdvancedAuth
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.0.0
+ */
+
 declare( strict_types=1 );
 
 namespace ArtisanPackUI\SecurityAdvancedAuth\Authentication\Social\Providers;
@@ -302,7 +313,7 @@ class AppleProvider extends AbstractOAuth2Provider
             }
 
             return $response->json();
-        });
+        } );
     }
 
     /**
@@ -310,7 +321,7 @@ class AppleProvider extends AbstractOAuth2Provider
      *
      * @param  array<string, mixed>  $data
      */
-    protected function mapUserData( array $data): SocialUser
+    protected function mapUserData( array $data ): SocialUser
     {
         throw new RuntimeException( 'Use getUserFromIdToken() for Apple Sign In');
     }

--- a/src/Authentication/Social/Providers/FacebookProvider.php
+++ b/src/Authentication/Social/Providers/FacebookProvider.php
@@ -1,5 +1,16 @@
 <?php
 
+/**
+ * FacebookProvider social OAuth provider.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SecurityAdvancedAuth
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.0.0
+ */
+
 declare( strict_types=1 );
 
 namespace ArtisanPackUI\SecurityAdvancedAuth\Authentication\Social\Providers;

--- a/src/Authentication/Social/Providers/GenericOidcProvider.php
+++ b/src/Authentication/Social/Providers/GenericOidcProvider.php
@@ -1,5 +1,16 @@
 <?php
 
+/**
+ * GenericOidcProvider social OAuth provider.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SecurityAdvancedAuth
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.0.0
+ */
+
 declare( strict_types=1 );
 
 namespace ArtisanPackUI\SecurityAdvancedAuth\Authentication\Social\Providers;

--- a/src/Authentication/Social/Providers/GitHubProvider.php
+++ b/src/Authentication/Social/Providers/GitHubProvider.php
@@ -1,5 +1,16 @@
 <?php
 
+/**
+ * GitHubProvider social OAuth provider.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SecurityAdvancedAuth
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.0.0
+ */
+
 declare( strict_types=1 );
 
 namespace ArtisanPackUI\SecurityAdvancedAuth\Authentication\Social\Providers;

--- a/src/Authentication/Social/Providers/GoogleProvider.php
+++ b/src/Authentication/Social/Providers/GoogleProvider.php
@@ -1,5 +1,16 @@
 <?php
 
+/**
+ * GoogleProvider social OAuth provider.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SecurityAdvancedAuth
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.0.0
+ */
+
 declare( strict_types=1 );
 
 namespace ArtisanPackUI\SecurityAdvancedAuth\Authentication\Social\Providers;

--- a/src/Authentication/Social/Providers/LinkedInProvider.php
+++ b/src/Authentication/Social/Providers/LinkedInProvider.php
@@ -1,5 +1,16 @@
 <?php
 
+/**
+ * LinkedInProvider social OAuth provider.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SecurityAdvancedAuth
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.0.0
+ */
+
 declare( strict_types=1 );
 
 namespace ArtisanPackUI\SecurityAdvancedAuth\Authentication\Social\Providers;

--- a/src/Authentication/Social/Providers/MicrosoftProvider.php
+++ b/src/Authentication/Social/Providers/MicrosoftProvider.php
@@ -1,5 +1,16 @@
 <?php
 
+/**
+ * MicrosoftProvider social OAuth provider.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SecurityAdvancedAuth
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.0.0
+ */
+
 declare( strict_types=1 );
 
 namespace ArtisanPackUI\SecurityAdvancedAuth\Authentication\Social\Providers;

--- a/src/Authentication/Social/SocialAuthManager.php
+++ b/src/Authentication/Social/SocialAuthManager.php
@@ -1,5 +1,16 @@
 <?php
 
+/**
+ * SocialAuthManager social authentication class.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SecurityAdvancedAuth
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.0.0
+ */
+
 declare( strict_types=1 );
 
 namespace ArtisanPackUI\SecurityAdvancedAuth\Authentication\Social;
@@ -350,11 +361,11 @@ class SocialAuthManager
             'email_verified_at' => $socialUser->isEmailVerified() ? now() : null,
         ];
 
-        $user = $userModel::create( $userData);
+        $user = $userModel::create( $userData );
 
         // Assign default role if configured
-        $defaultRole = config( 'artisanpack.security-advanced-auth.social.default_role');
-        if ( $defaultRole && method_exists( $user, 'assignRole')) {
+        $defaultRole = config( 'artisanpack.security-advanced-auth.social.default_role' );
+        if ( $defaultRole && method_exists( $user, 'assignRole' ) ) {
             $user->assignRole( $defaultRole);
         }
 

--- a/src/Authentication/Social/SocialAuthManager.php
+++ b/src/Authentication/Social/SocialAuthManager.php
@@ -366,7 +366,7 @@ class SocialAuthManager
         // Assign default role if configured
         $defaultRole = config( 'artisanpack.security-advanced-auth.social.default_role' );
         if ( $defaultRole && method_exists( $user, 'assignRole' ) ) {
-            $user->assignRole( $defaultRole);
+            $user->assignRole( $defaultRole );
         }
 
         return $user;

--- a/src/Authentication/Social/SocialUser.php
+++ b/src/Authentication/Social/SocialUser.php
@@ -1,5 +1,16 @@
 <?php
 
+/**
+ * SocialUser social authentication class.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SecurityAdvancedAuth
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.0.0
+ */
+
 declare( strict_types=1 );
 
 namespace ArtisanPackUI\SecurityAdvancedAuth\Authentication\Social;

--- a/src/Authentication/Sso/Ldap/LdapAuthenticator.php
+++ b/src/Authentication/Sso/Ldap/LdapAuthenticator.php
@@ -1,5 +1,16 @@
 <?php
 
+/**
+ * LdapAuthenticator LDAP SSO class.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SecurityAdvancedAuth
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.0.0
+ */
+
 declare( strict_types=1 );
 
 namespace ArtisanPackUI\SecurityAdvancedAuth\Authentication\Sso\Ldap;
@@ -364,10 +375,10 @@ class LdapAuthenticator implements SsoProviderInterface
 
         return sprintf(
             '%s-%s-%s-%s-%s',
-            substr( $hex, 6, 2 ) . substr( $hex, 4, 2 ) . substr( $hex, 2, 2 ) . substr( $hex, 0, 2),
-            substr( $hex, 10, 2) . substr( $hex, 8, 2),
-            substr( $hex, 14, 2) . substr( $hex, 12, 2),
-            substr( $hex, 16, 4),
+            substr( $hex, 6, 2 ) . substr( $hex, 4, 2 ) . substr( $hex, 2, 2 ) . substr( $hex, 0, 2 ),
+            substr( $hex, 10, 2 ) . substr( $hex, 8, 2 ),
+            substr( $hex, 14, 2 ) . substr( $hex, 12, 2 ),
+            substr( $hex, 16, 4 ),
             substr( $hex, 20, 12),
         );
     }

--- a/src/Authentication/Sso/Oidc/OidcClient.php
+++ b/src/Authentication/Sso/Oidc/OidcClient.php
@@ -1,5 +1,16 @@
 <?php
 
+/**
+ * OidcClient OIDC SSO class.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SecurityAdvancedAuth
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.0.0
+ */
+
 declare( strict_types=1 );
 
 namespace ArtisanPackUI\SecurityAdvancedAuth\Authentication\Sso\Oidc;

--- a/src/Authentication/Sso/Saml/SamlServiceProvider.php
+++ b/src/Authentication/Sso/Saml/SamlServiceProvider.php
@@ -1,5 +1,16 @@
 <?php
 
+/**
+ * SamlServiceProvider SAML SSO class.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SecurityAdvancedAuth
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.0.0
+ */
+
 declare( strict_types=1 );
 
 namespace ArtisanPackUI\SecurityAdvancedAuth\Authentication\Sso\Saml;
@@ -573,10 +584,10 @@ XML;
      *
      * @param  array<string, mixed>  $options
      */
-    protected function buildLogoutRequest( array $options): string
+    protected function buildLogoutRequest( array $options ): string
     {
         $id           = '_' . Str::uuid()->toString();
-        $issueInstant = gmdate( 'Y-m-d\TH:i:s\Z');
+        $issueInstant = gmdate( 'Y-m-d\TH:i:s\Z' );
         $nameId       = $options['name_id'] ?? '';
         $sessionIndex = $options['session_index'] ?? '';
 

--- a/src/Authentication/Sso/SsoManager.php
+++ b/src/Authentication/Sso/SsoManager.php
@@ -1,5 +1,16 @@
 <?php
 
+/**
+ * SsoManager SSO class.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SecurityAdvancedAuth
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.0.0
+ */
+
 declare( strict_types=1 );
 
 namespace ArtisanPackUI\SecurityAdvancedAuth\Authentication\Sso;
@@ -289,11 +300,11 @@ class SsoManager
             'email_verified_at' => now(), // SSO users are pre-verified
         ];
 
-        $user = $userModel::create( $userData);
+        $user = $userModel::create( $userData );
 
         // Assign default role if configured
-        $defaultRole = config( 'artisanpack.security-advanced-auth.sso.default_role');
-        if ( $defaultRole && method_exists( $user, 'assignRole')) {
+        $defaultRole = config( 'artisanpack.security-advanced-auth.sso.default_role' );
+        if ( $defaultRole && method_exists( $user, 'assignRole' ) ) {
             $user->assignRole( $defaultRole);
         }
 

--- a/src/Authentication/Sso/SsoUser.php
+++ b/src/Authentication/Sso/SsoUser.php
@@ -1,5 +1,16 @@
 <?php
 
+/**
+ * SsoUser SSO class.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SecurityAdvancedAuth
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.0.0
+ */
+
 declare( strict_types=1 );
 
 namespace ArtisanPackUI\SecurityAdvancedAuth\Authentication\Sso;

--- a/src/Authentication/WebAuthn/WebAuthnManager.php
+++ b/src/Authentication/WebAuthn/WebAuthnManager.php
@@ -1,5 +1,16 @@
 <?php
 
+/**
+ * WebAuthnManager WebAuthn class.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SecurityAdvancedAuth
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.0.0
+ */
+
 declare( strict_types=1 );
 
 namespace ArtisanPackUI\SecurityAdvancedAuth\Authentication\WebAuthn;
@@ -549,28 +560,28 @@ class WebAuthnManager implements WebAuthnInterface
         // For now, use chunking to avoid loading all into memory at once
         $found = null;
         WebAuthnCredential::chunk( 100, function ( $credentials ) use ( $credentialId, &$found ) {
-            foreach ( $credentials as $credential) {
-                if ( $credential->credential_id === $credentialId) {
+            foreach ( $credentials as $credential ) {
+                if ( $credential->credential_id === $credentialId ) {
                     $found = $credential;
                     return false; // Stop chunking
                 }
             }
-        });
+        } );
         return $found;
     }
 
     /**
      * Base64 URL encode.
      */
-    protected function base64UrlEncode( string $data): string
+    protected function base64UrlEncode( string $data ): string
     {
-        return rtrim( strtr( base64_encode( $data), '+/', '-_'), '=');
+        return rtrim( strtr( base64_encode( $data ), '+/', '-_' ), '=' );
     }
 
     /**
      * Base64 URL decode.
      */
-    protected function base64UrlDecode( string $data): string
+    protected function base64UrlDecode( string $data ): string
     {
         return base64_decode( strtr( $data, '-_', '+/'));
     }

--- a/src/Http/Controllers/SocialAuthController.php
+++ b/src/Http/Controllers/SocialAuthController.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * SocialAuthController controller.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SecurityAdvancedAuth
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\SecurityAdvancedAuth\Http\Controllers;
+
+use ArtisanPackUI\SecurityAdvancedAuth\Authentication\Social\SocialAuthManager;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use RuntimeException;
+
+class SocialAuthController
+{
+    public function __construct(
+        protected SocialAuthManager $manager,
+    ) {
+    }
+
+    /**
+     * Redirect the user to the provider's authorization page.
+     */
+    public function redirect( string $provider ): RedirectResponse
+    {
+        $this->assertProviderRegistered( $provider );
+
+        $url = $this->manager->redirect( $provider );
+
+        return redirect()->away( $url );
+    }
+
+    /**
+     * Handle the OAuth callback from the provider.
+     */
+    public function callback( string $provider, Request $request ): RedirectResponse
+    {
+        $this->assertProviderRegistered( $provider );
+
+        $code  = (string) $request->query( 'code', '' );
+        $state = (string) $request->query( 'state', '' );
+
+        $result = $this->manager->callback( $provider, $code, $state );
+
+        if ( ! empty( $result['user'] ) ) {
+            Auth::login( $result['user'] );
+        }
+
+        $intended = config( 'artisanpack.security-advanced-auth.social.redirect_after_login', '/' );
+
+        return redirect()->intended( $intended );
+    }
+
+    /**
+     * Unlink a connected provider from the authenticated user.
+     */
+    public function unlink( string $provider ): RedirectResponse
+    {
+        $this->assertProviderRegistered( $provider );
+
+        $user = Auth::user();
+
+        if ( ! $user ) {
+            abort( 401 );
+        }
+
+        $this->manager->unlinkIdentity( $user, $provider );
+
+        return back()->with( 'status', "{$provider} disconnected." );
+    }
+
+    protected function assertProviderRegistered( string $provider ): void
+    {
+        if ( ! $this->manager->hasProvider( $provider ) ) {
+            throw new RuntimeException( "Social provider not registered: {$provider}" );
+        }
+    }
+}

--- a/src/Http/Controllers/SsoController.php
+++ b/src/Http/Controllers/SsoController.php
@@ -1,0 +1,98 @@
+<?php
+
+/**
+ * SsoController controller.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SecurityAdvancedAuth
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\SecurityAdvancedAuth\Http\Controllers;
+
+use ArtisanPackUI\SecurityAdvancedAuth\Authentication\Sso\SsoManager;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Auth;
+
+class SsoController
+{
+    public function __construct(
+        protected SsoManager $manager,
+    ) {
+    }
+
+    /**
+     * Begin the SSO login flow — redirect to the IdP.
+     */
+    public function login( string $slug ): RedirectResponse
+    {
+        $url = $this->manager->login( $slug );
+
+        return redirect()->away( $url );
+    }
+
+    /**
+     * Handle the SSO callback from the IdP (SAML ACS, OIDC code response).
+     */
+    public function callback( string $slug, Request $request ): RedirectResponse
+    {
+        $ssoUser = $this->manager->callback( $slug, $request );
+        $user    = $this->manager->findOrCreateUser( $ssoUser );
+
+        if ( $user ) {
+            Auth::login( $user );
+        }
+
+        $intended = config( 'artisanpack.security-advanced-auth.sso.redirect_after_login', '/' );
+
+        return redirect()->intended( $intended );
+    }
+
+    /**
+     * Begin SLO (Single Logout) — redirect to the IdP's logout endpoint.
+     */
+    public function logout( string $slug ): RedirectResponse
+    {
+        $url = $this->manager->logout( $slug );
+
+        Auth::logout();
+
+        if ( $url ) {
+            return redirect()->away( $url );
+        }
+
+        return redirect( '/' );
+    }
+
+    /**
+     * Handle the IdP's SLO callback.
+     */
+    public function logoutCallback( string $slug, Request $request ): RedirectResponse
+    {
+        $this->manager->handleLogout( $slug, $request );
+
+        return redirect( '/' );
+    }
+
+    /**
+     * SAML SP metadata endpoint — returns the metadata XML the IdP needs to
+     * federate with this app.
+     */
+    public function metadata( string $slug ): Response
+    {
+        $xml = $this->manager->getMetadata( $slug );
+
+        if ( ! $xml ) {
+            abort( 404 );
+        }
+
+        return response( $xml, 200, ['Content-Type' => 'application/xml'] );
+    }
+}

--- a/src/Http/Controllers/WebAuthnController.php
+++ b/src/Http/Controllers/WebAuthnController.php
@@ -1,0 +1,112 @@
+<?php
+
+/**
+ * WebAuthnController controller.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SecurityAdvancedAuth
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.0.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\SecurityAdvancedAuth\Http\Controllers;
+
+use ArtisanPackUI\SecurityAdvancedAuth\Authentication\WebAuthn\WebAuthnManager;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class WebAuthnController
+{
+    public function __construct(
+        protected WebAuthnManager $manager,
+    ) {
+    }
+
+    /**
+     * Generate registration options. Host JS passes these to
+     * navigator.credentials.create().
+     */
+    public function registerOptions( Request $request ): JsonResponse
+    {
+        $user = Auth::user();
+
+        if ( ! $user ) {
+            abort( 401 );
+        }
+
+        $options = $this->manager->generateRegistrationOptions(
+            user: $user,
+            options: $request->all(),
+        );
+
+        return response()->json( $options );
+    }
+
+    /**
+     * Verify the response from navigator.credentials.create().
+     */
+    public function registerVerify( Request $request ): JsonResponse
+    {
+        $user = Auth::user();
+
+        if ( ! $user ) {
+            abort( 401 );
+        }
+
+        $validated = $request->validate( [
+            'response'  => ['required', 'array'],
+            'challenge' => ['required', 'string'],
+        ] );
+
+        $result = $this->manager->verifyRegistration(
+            user: $user,
+            response: $validated['response'],
+            challenge: $validated['challenge'],
+        );
+
+        return response()->json( $result );
+    }
+
+    /**
+     * Generate authentication options. Host JS passes these to
+     * navigator.credentials.get().
+     */
+    public function authenticateOptions( Request $request ): JsonResponse
+    {
+        $user = Auth::user();   // null is OK — supports passkey discovery flows
+
+        $options = $this->manager->generateAuthenticationOptions(
+            user: $user,
+            options: $request->all(),
+        );
+
+        return response()->json( $options );
+    }
+
+    /**
+     * Verify the response from navigator.credentials.get().
+     */
+    public function authenticateVerify( Request $request ): JsonResponse
+    {
+        $validated = $request->validate( [
+            'response'  => ['required', 'array'],
+            'challenge' => ['required', 'string'],
+        ] );
+
+        $result = $this->manager->verifyAuthentication(
+            response: $validated['response'],
+            challenge: $validated['challenge'],
+        );
+
+        if ( ! empty( $result['user'] ) ) {
+            Auth::login( $result['user'] );
+        }
+
+        return response()->json( $result );
+    }
+}

--- a/src/Http/Controllers/WebAuthnController.php
+++ b/src/Http/Controllers/WebAuthnController.php
@@ -105,6 +105,7 @@ class WebAuthnController
 
         if ( ! empty( $result['user'] ) ) {
             Auth::login( $result['user'] );
+            unset( $result['user'] );
         }
 
         return response()->json( $result );

--- a/src/Livewire/BiometricManager.php
+++ b/src/Livewire/BiometricManager.php
@@ -1,5 +1,16 @@
 <?php
 
+/**
+ * BiometricManager Livewire component.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SecurityAdvancedAuth
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.0.0
+ */
+
 declare( strict_types=1 );
 
 namespace ArtisanPackUI\SecurityAdvancedAuth\Livewire;

--- a/src/Livewire/DeviceManager.php
+++ b/src/Livewire/DeviceManager.php
@@ -1,5 +1,16 @@
 <?php
 
+/**
+ * DeviceManager Livewire component.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SecurityAdvancedAuth
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.0.0
+ */
+
 declare( strict_types=1 );
 
 namespace ArtisanPackUI\SecurityAdvancedAuth\Livewire;
@@ -188,8 +199,8 @@ class DeviceManager extends Component
             $device->city,
             $device->region,
             $device->country,
-        ]);
+        ] );
 
-        return implode( ', ', $parts) ?: 'Unknown location';
+        return implode( ', ', $parts ) ?: 'Unknown location';
     }
 }

--- a/src/Livewire/SocialAccountsManager.php
+++ b/src/Livewire/SocialAccountsManager.php
@@ -1,5 +1,16 @@
 <?php
 
+/**
+ * SocialAccountsManager Livewire component.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SecurityAdvancedAuth
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.0.0
+ */
+
 declare( strict_types=1 );
 
 namespace ArtisanPackUI\SecurityAdvancedAuth\Livewire;

--- a/src/Livewire/SuspiciousActivityList.php
+++ b/src/Livewire/SuspiciousActivityList.php
@@ -1,5 +1,16 @@
 <?php
 
+/**
+ * SuspiciousActivityList Livewire component.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SecurityAdvancedAuth
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.0.0
+ */
+
 declare( strict_types=1 );
 
 namespace ArtisanPackUI\SecurityAdvancedAuth\Livewire;
@@ -69,13 +80,14 @@ class SuspiciousActivityList extends Component
             SuspiciousActivity::TYPE_IMPOSSIBLE_TRAVEL   => 'Impossible Travel',
             SuspiciousActivity::TYPE_BRUTE_FORCE         => 'Brute Force',
             SuspiciousActivity::TYPE_CREDENTIAL_STUFFING => 'Credential Stuffing',
-            SuspiciousActivity::TYPE_UNUSUAL_LOCATION    => 'Unusual Location',
-            SuspiciousActivity::TYPE_UNUSUAL_DEVICE      => 'Unusual Device',
+            SuspiciousActivity::TYPE_ANOMALOUS_LOGIN     => 'Anomalous Login',
+            SuspiciousActivity::TYPE_PROXY_DETECTED      => 'Proxy Detected',
+            SuspiciousActivity::TYPE_TOR_DETECTED        => 'Tor Detected',
+            SuspiciousActivity::TYPE_DATACENTER_IP       => 'Datacenter IP',
+            SuspiciousActivity::TYPE_MULTIPLE_FAILURES   => 'Multiple Failures',
+            SuspiciousActivity::TYPE_DEVICE_CHANGE       => 'Device Change',
             SuspiciousActivity::TYPE_UNUSUAL_TIME        => 'Unusual Time',
-            SuspiciousActivity::TYPE_RAPID_REQUESTS      => 'Rapid Requests',
-            SuspiciousActivity::TYPE_BOT_BEHAVIOR        => 'Bot Behavior',
-            SuspiciousActivity::TYPE_SESSION_ANOMALY     => 'Session Anomaly',
-            SuspiciousActivity::TYPE_ACCOUNT_ENUMERATION => 'Account Enumeration',
+            SuspiciousActivity::TYPE_SESSION_HIJACKING   => 'Session Hijacking',
         ];
     }
 
@@ -94,6 +106,6 @@ class SuspiciousActivityList extends Component
     {
         return view( 'security-advanced-auth::livewire.suspicious-activity-list', [
             'activities' => $this->activities,
-        ]);
+        ] );
     }
 }

--- a/src/Livewire/WebAuthnCredentialsManager.php
+++ b/src/Livewire/WebAuthnCredentialsManager.php
@@ -1,5 +1,16 @@
 <?php
 
+/**
+ * WebAuthnCredentialsManager Livewire component.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SecurityAdvancedAuth
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.0.0
+ */
+
 declare( strict_types=1 );
 
 namespace ArtisanPackUI\SecurityAdvancedAuth\Livewire;
@@ -163,6 +174,6 @@ class WebAuthnCredentialsManager extends Component
 
     public function render()
     {
-        return view( 'security-advanced-auth::livewire.webauthn-credentials-manager');
+        return view( 'security-advanced-auth::livewire.webauthn-credentials-manager' );
     }
 }

--- a/src/Models/DeviceFingerprint.php
+++ b/src/Models/DeviceFingerprint.php
@@ -1,5 +1,16 @@
 <?php
 
+/**
+ * DeviceFingerprint Eloquent model.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SecurityAdvancedAuth
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.0.0
+ */
+
 declare( strict_types=1 );
 
 namespace ArtisanPackUI\SecurityAdvancedAuth\Models;
@@ -103,6 +114,6 @@ class DeviceFingerprint extends Model
             if ( ! $model->created_at ) {
                 $model->created_at = now();
             }
-        });
+        } );
     }
 }

--- a/src/Models/SocialIdentity.php
+++ b/src/Models/SocialIdentity.php
@@ -1,5 +1,16 @@
 <?php
 
+/**
+ * SocialIdentity Eloquent model.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SecurityAdvancedAuth
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.0.0
+ */
+
 declare( strict_types=1 );
 
 namespace ArtisanPackUI\SecurityAdvancedAuth\Models;

--- a/src/Models/SsoConfiguration.php
+++ b/src/Models/SsoConfiguration.php
@@ -1,5 +1,16 @@
 <?php
 
+/**
+ * SsoConfiguration Eloquent model.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SecurityAdvancedAuth
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.0.0
+ */
+
 declare( strict_types=1 );
 
 namespace ArtisanPackUI\SecurityAdvancedAuth\Models;
@@ -325,8 +336,8 @@ class SsoConfiguration extends Model
         foreach ( $this->sensitiveSettingsKeys as $key ) {
             if ( isset( $settings[ $key ] ) && is_array( $settings[ $key ] ) && ( $settings[ $key ]['__encrypted'] ?? false ) ) {
                 try {
-                    $settings[ $key ] = Crypt::decryptString( $settings[ $key ]['value']);
-                } catch ( Exception) {
+                    $settings[ $key ] = Crypt::decryptString( $settings[ $key ]['value'] );
+                } catch ( Exception ) {
                     $settings[ $key ] = null;
                 }
             }

--- a/src/Models/SsoIdentity.php
+++ b/src/Models/SsoIdentity.php
@@ -1,5 +1,16 @@
 <?php
 
+/**
+ * SsoIdentity Eloquent model.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SecurityAdvancedAuth
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.0.0
+ */
+
 declare( strict_types=1 );
 
 namespace ArtisanPackUI\SecurityAdvancedAuth\Models;

--- a/src/Models/SuspiciousActivity.php
+++ b/src/Models/SuspiciousActivity.php
@@ -1,5 +1,16 @@
 <?php
 
+/**
+ * SuspiciousActivity Eloquent model.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SecurityAdvancedAuth
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.0.0
+ */
+
 declare( strict_types=1 );
 
 namespace ArtisanPackUI\SecurityAdvancedAuth\Models;
@@ -301,7 +312,7 @@ class SuspiciousActivity extends Model
             if ( ! $model->created_at ) {
                 $model->created_at = now();
             }
-            if ( null === $model->details) {
+            if ( null === $model->details ) {
                 $model->details = [];
             }
         });

--- a/src/Models/UserDevice.php
+++ b/src/Models/UserDevice.php
@@ -1,5 +1,16 @@
 <?php
 
+/**
+ * UserDevice Eloquent model.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SecurityAdvancedAuth
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.0.0
+ */
+
 declare( strict_types=1 );
 
 namespace ArtisanPackUI\SecurityAdvancedAuth\Models;

--- a/src/Models/WebAuthnCredential.php
+++ b/src/Models/WebAuthnCredential.php
@@ -1,5 +1,16 @@
 <?php
 
+/**
+ * WebAuthnCredential Eloquent model.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SecurityAdvancedAuth
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.0.0
+ */
+
 declare( strict_types=1 );
 
 namespace ArtisanPackUI\SecurityAdvancedAuth\Models;

--- a/src/SecurityAdvancedAuthServiceProvider.php
+++ b/src/SecurityAdvancedAuthServiceProvider.php
@@ -1,5 +1,16 @@
 <?php
 
+/**
+ * Security Advanced Auth service provider.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SecurityAdvancedAuth
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.0.0
+ */
+
 declare( strict_types=1 );
 
 namespace ArtisanPackUI\SecurityAdvancedAuth;
@@ -47,8 +58,19 @@ class SecurityAdvancedAuthServiceProvider extends ServiceProvider
             'security-advanced-auth-config',
         );
 
+        $this->publishes(
+            [
+                __DIR__ . '/../resources/views' => resource_path( 'views/vendor/security-advanced-auth' ),
+            ],
+            'security-advanced-auth-views',
+        );
+
         $this->loadMigrationsFrom( __DIR__ . '/../database/migrations/authentication' );
         $this->loadViewsFrom( __DIR__ . '/../resources/views', 'security-advanced-auth' );
+
+        if ( config( 'artisanpack.security-advanced-auth.routes.enabled', true ) ) {
+            $this->loadRoutesFrom( __DIR__ . '/../routes/auth.php' );
+        }
 
         $this->registerLivewireComponents();
     }

--- a/tests/Feature/Livewire/ComponentRenderTest.php
+++ b/tests/Feature/Livewire/ComponentRenderTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\SecurityAdvancedAuth\Livewire\BiometricManager;
+use ArtisanPackUI\SecurityAdvancedAuth\Livewire\DeviceManager;
+use ArtisanPackUI\SecurityAdvancedAuth\Livewire\SocialAccountsManager;
+use ArtisanPackUI\SecurityAdvancedAuth\Livewire\SuspiciousActivityList;
+use ArtisanPackUI\SecurityAdvancedAuth\Livewire\WebAuthnCredentialsManager;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Foundation\Auth\User as Authenticatable;
+use Illuminate\Support\Facades\Schema;
+use Livewire\Livewire;
+
+beforeEach( function (): void {
+    // Migrations alter a `users` table that doesn't exist in testbench.
+    if ( ! Schema::hasTable( 'users' ) ) {
+        Schema::create( 'users', function ( Blueprint $table ): void {
+            $table->id();
+            $table->string( 'name' );
+            $table->string( 'email' )->unique();
+            $table->timestamp( 'email_verified_at' )->nullable();
+            $table->string( 'password' );
+            $table->rememberToken();
+            $table->timestamps();
+        } );
+    }
+
+    $this->artisan( 'migrate' );
+
+    $this->actingAs( new class extends Authenticatable {
+        public $id = 1;
+
+        protected $guarded = [];
+
+        public function getAuthIdentifier()
+        {
+            return 1;
+        }
+    } );
+} );
+
+it( 'renders the BiometricManager Livewire component', function (): void {
+    Livewire::test( BiometricManager::class )
+        ->assertStatus( 200 );
+} );
+
+it( 'renders the DeviceManager Livewire component', function (): void {
+    Livewire::test( DeviceManager::class )
+        ->assertStatus( 200 );
+} );
+
+it( 'renders the SocialAccountsManager Livewire component', function (): void {
+    Livewire::test( SocialAccountsManager::class )
+        ->assertStatus( 200 );
+} );
+
+it( 'renders the SuspiciousActivityList Livewire component', function (): void {
+    Livewire::test( SuspiciousActivityList::class )
+        ->assertStatus( 200 );
+} );
+
+it( 'renders the WebAuthnCredentialsManager Livewire component', function (): void {
+    Livewire::test( WebAuthnCredentialsManager::class )
+        ->assertStatus( 200 );
+} );

--- a/tests/Feature/RoutesRegisteredTest.php
+++ b/tests/Feature/RoutesRegisteredTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare( strict_types=1 );
+
+use Illuminate\Support\Facades\Route;
+
+it( 'registers all social, sso, and webauthn routes when enabled', function (): void {
+    $expected = [
+        'security-advanced-auth.social.redirect',
+        'security-advanced-auth.social.callback',
+        'security-advanced-auth.social.unlink',
+        'security-advanced-auth.sso.login',
+        'security-advanced-auth.sso.callback',
+        'security-advanced-auth.sso.logout',
+        'security-advanced-auth.sso.logout.callback',
+        'security-advanced-auth.sso.metadata',
+        'security-advanced-auth.webauthn.register.options',
+        'security-advanced-auth.webauthn.register.verify',
+        'security-advanced-auth.webauthn.authenticate.options',
+        'security-advanced-auth.webauthn.authenticate.verify',
+    ];
+
+    $routes = collect( Route::getRoutes()->getRoutes() )
+        ->map( fn ( $route ) => $route->getName() )
+        ->filter()
+        ->values()
+        ->all();
+
+    foreach ( $expected as $name ) {
+        expect( $routes )->toContain( $name );
+    }
+} );

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -5,6 +5,7 @@ declare( strict_types=1 );
 namespace Tests;
 
 use ArtisanPackUI\SecurityAdvancedAuth\SecurityAdvancedAuthServiceProvider;
+use Livewire\LivewireServiceProvider;
 use Orchestra\Testbench\TestCase as BaseTestCase;
 
 /**
@@ -36,6 +37,7 @@ abstract class TestCase extends BaseTestCase
     protected function getPackageProviders( $app ): array
     {
         return [
+            LivewireServiceProvider::class,
             SecurityAdvancedAuthServiceProvider::class,
         ];
     }


### PR DESCRIPTION
## Summary

Closes #12.
Closes #13.

Brings the package up to the ArtisanPack UI ecosystem release standard (composer.json, LICENSE, README, CHANGELOG, CONTRIBUTING, docs/, PHPDoc, lint, tests) and bumps the version to 1.0.0. Wave 2 unblocking work shipped the 5 missing Livewire Blade views, the `routes/auth.php` file with 12 social / SSO / WebAuthn callback endpoints, and 3 thin HTTP controllers delegating to the manager services.

See the commit body for the per-phase detail.

## Test plan

- [x] composer validate clean
- [x] composer lint clean
- [x] composer test all-green (11 passed, 22 assertions)
- [ ] CodeRabbit auto-review on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Complete docs added: getting started, installation/configuration, usage, advanced guides, FAQ, troubleshooting; changelog and README updated.

* **New Features**
  * Livewire UIs for passkeys, biometrics, trusted devices, social accounts, and suspicious-activity.
  * HTTP endpoints/controllers and configurable routes for social auth, SSO, and WebAuthn; view publishing support.

* **Tests**
  * Feature tests rendering components and verifying route registration.

* **Chores**
  * Version bumped to 1.0.0, license switched to MIT; CI/CD and automation workflows added/updated (lint/test/matrix/release/auto-milestone/AI review).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArtisanPack-UI/security-advanced-auth/pull/14?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->